### PR TITLE
Feature/auth handling

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -415,16 +415,16 @@ export class Client {
                 "<small>You may need to sign a new challenge in your wallet</small>"
             );
 
-        const addressMatch = await this.checkPublicAddressMatch(issuer, unsignedToken);
-
-        // e.g. create warning notification inside overlay.
-        if(!addressMatch) {
-            if (this.popup)
-                this.popup.showError("Address does not match.");
-            return;
-        }
-
         try {
+            const addressMatch = await this.checkPublicAddressMatch(issuer, unsignedToken);
+
+            // e.g. create warning notification inside overlay.
+            if(!addressMatch) {
+                if (this.popup)
+                    this.popup.showError("Address does not match.");
+                return;
+            }
+
             let data = await this.messaging.sendMessage({
                 issuer: issuer,
                 action: MessageAction.GET_PROOF,

--- a/src/outlet/auth-handler.ts
+++ b/src/outlet/auth-handler.ts
@@ -58,6 +58,19 @@ export class AuthHandler {
                 return reject("Attestation origin is null");
 
             window.addEventListener("message", (e) => {
+
+                if (!this.attestationOrigin)
+                    return;
+
+                let attestURL = new URL(this.attestationOrigin);
+
+                if (e.origin !== attestURL.origin) {
+                    return;
+                }
+
+                if (!this.iframe || !this.iframeWrap || !this.iframe.contentWindow)
+                    return;
+
                 this.postMessageAttestationListener(e, resolve, reject);
             });
 
@@ -87,18 +100,6 @@ export class AuthHandler {
     }
 
     postMessageAttestationListener(event: MessageEvent, resolve:Function, reject:Function){
-
-        if (!this.iframe || !this.iframeWrap || !this.iframe.contentWindow)
-            return;
-
-        if (!this.attestationOrigin)
-            return;
-
-        let attestURL = new URL(this.attestationOrigin);
-
-        if (event.origin !== attestURL.origin) {
-            return;
-        }
 
         console.log('postMessageAttestationListener event (Authenticator)',event);
 

--- a/src/outlet/auth-handler.ts
+++ b/src/outlet/auth-handler.ts
@@ -1,0 +1,198 @@
+import {Item} from '../tokenLookup'
+import {MessageResponseAction} from '../client/messaging'
+import {Outlet} from "./index";
+
+export interface DevconToken {
+    ticketBlob: string,
+    ticketSecret: bigint,
+    email?: string,
+    magicLink?: string,
+    attestationOrigin: string,
+}
+
+interface PostMessageData {
+    force?: boolean,
+    email?: string,
+    magicLink?: string,
+}
+
+export class AuthHandler {
+
+    private outlet:Outlet;
+    private evtid:any;
+
+    private signedTokenBlob:string|undefined;
+    private magicLink:string|undefined;
+    private email:string|undefined;
+    private signedTokenSecret:bigint|undefined;
+    private attestationOrigin:string|undefined;
+
+    private iframe:HTMLIFrameElement|null = null;
+    private iframeWrap:HTMLElement|null = null;
+
+    private attestationBlob:string|null = null;
+    private attestationSecret:bigint|null = null;
+
+    private base64attestorPubKey:string|undefined;
+    private base64senderPublicKey:string|undefined;
+
+    constructor(outlet:Outlet, evtid:any, tokenDef:Item, tokenObj:DevconToken|any) {
+        this.outlet = outlet;
+        this.evtid = evtid;
+        this.base64senderPublicKey = tokenDef.base64senderPublicKey;
+        this.base64attestorPubKey = tokenDef.base64attestorPubKey;
+
+        this.signedTokenBlob = tokenObj.ticketBlob;
+        this.magicLink = tokenObj.magicLink;
+        this.email = tokenObj.email;
+        this.signedTokenSecret = tokenObj.ticketSecret;
+        this.attestationOrigin = tokenObj.attestationOrigin;
+    }
+
+    // TODO: combine functionality with messaging to enable tab support? Changes required in attestation.id code
+    public authenticate(){
+
+        return new Promise((resolve, reject) => {
+
+            if (!this.attestationOrigin)
+                return reject("Attestation origin is null");
+
+            window.addEventListener("message", (e) => {
+                this.postMessageAttestationListener(e, resolve, reject);
+            });
+
+            this.createIframe();
+
+        });
+
+    }
+
+    private createIframe(){
+
+        const iframe = document.createElement('iframe');
+        this.iframe = iframe;
+
+        iframe.src = this.attestationOrigin ?? "";
+        iframe.style.width = '800px';
+        iframe.style.height = '700px';
+        iframe.style.maxWidth = '100%';
+        iframe.style.background = '#fff';
+
+        let iframeWrap = document.createElement('div');
+        this.iframeWrap = iframeWrap;
+        iframeWrap.setAttribute('style', 'width:100%;min-height: 100vh; position: fixed; align-items: center; justify-content: center;display: none;top: 0; left: 0; background: #fffa');
+        iframeWrap.appendChild(iframe);
+
+        document.body.appendChild(iframeWrap);
+    }
+
+    postMessageAttestationListener(event: MessageEvent, resolve:Function, reject:Function){
+
+        if (!this.iframe || !this.iframeWrap || !this.iframe.contentWindow)
+            return;
+
+        if (!this.attestationOrigin)
+            return;
+
+        let attestURL = new URL(this.attestationOrigin);
+
+        if (event.origin !== attestURL.origin) {
+            return;
+        }
+
+        console.log('postMessageAttestationListener event (Authenticator)',event);
+
+        if (
+            typeof event.data.ready !== "undefined"
+            && event.data.ready === true
+        ) {
+            let sendData:PostMessageData = {force: false};
+            if (this.magicLink) sendData.magicLink = this.magicLink;
+            if (this.email) sendData.email = this.email;
+
+            this.iframe.contentWindow.postMessage(sendData, this.attestationOrigin);
+            return;
+        }
+
+
+        if (
+            typeof event.data.display !== "undefined"
+        ) {
+            if (event.data.display === true) {
+
+                this.iframeWrap.style.display = 'flex';
+                //this.negotiator && this.negotiator.commandDisplayIframe();
+                
+                this.outlet.sendMessageResponse({
+                    evtid: this.evtid,
+                    evt: MessageResponseAction.SHOW_FRAME
+                });
+                
+                
+            } else {
+
+                if (event.data.error){
+                    console.log("Error received from the iframe: " + event.data.error);
+                    reject(event.data.error);
+                }
+
+                this.iframeWrap.style.display = 'none';
+                //this.negotiator && this.negotiator.commandHideIframe();
+
+            }
+        }
+
+        if (
+            !event.data.hasOwnProperty('attestation')
+            || !event.data.hasOwnProperty('requestSecret')
+        ) {
+            return;
+        }
+        this.iframeWrap.remove();
+        this.attestationBlob = event.data.attestation;
+        this.attestationSecret = event.data.requestSecret;
+
+        console.log('attestation data received.');
+        console.log(this.attestationBlob);
+        console.log(this.attestationSecret);
+        console.log(this.base64attestorPubKey);
+
+        try {
+
+            // @ts-ignore
+            window.authenticator.getUseTicket(
+                this.signedTokenSecret,
+                this.attestationSecret,
+                this.signedTokenBlob ,
+                this.attestationBlob ,
+                this.base64attestorPubKey,
+                this.base64senderPublicKey,
+            ).then((useToken:any) => {
+                if (useToken){
+                    console.log('this.authResultCallback( useToken ): ');
+                    resolve(useToken);
+                } else {
+                    console.log('this.authResultCallback( empty ): ');
+                    reject(useToken);
+                }
+
+            });
+
+
+        } catch (e){
+            console.log(`UseDevconTicket. Something went wrong. ${e}`);
+            reject(e);
+        }
+        // construct UseDevconTicket, see
+        // https://github.com/TokenScript/attestation/blob/main/data-modules/src/UseDevconTicket.asd
+
+        // TODO we dont have ready UseDevconTicket constructor yet
+        // let useDevconTicket = new UseDevconTicket({
+        //     signedDevconTicket: signedDevonTicket,
+        //     identifierAttestation: identifierAttestation,
+        //     proof: proof
+        // })
+        // // Serialise it (for use as a transaction parameter) and return it
+        // return useDevconTicket.serialize();
+    }
+}

--- a/src/theme/style.css
+++ b/src/theme/style.css
@@ -787,3 +787,76 @@ li.issuer-connect-banner-tn .tokens-btn-tn {
   }
 }
 
+/* Modal for handling input required by attestation.ID (wallet connection setup for instance) */
+.modal-tn {
+  display: none;
+  position: fixed;
+  z-index: 999;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0,0,0,0.5);
+}
+
+.modal-close-tn {
+  color: #ffffff;
+  float: right;
+  font-size: 50px;
+  font-weight: bold;
+}
+
+.modal-close-tn:hover,
+.modal-close-tn:focus {
+  color: #696969;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: all 200ms ease-in;
+  transition: all 200ms ease-in;
+}
+
+.modal-header-tn {
+  padding: 2px 16px;
+  /*background-color: #5cb85c;*/
+  color: white;
+}
+
+.modal-body-tn {
+  padding: 2px 16px;
+}
+
+.modal-body-tn iframe {
+  width: 100%;
+  min-height: 400px;
+  background-color: #fff;
+  border: 6px solid #696969;
+  border-radius: 3px;
+}
+
+/* Modal Content */
+.modal-content-tn {
+  position: relative;
+  background-color: transparent;
+  margin: auto;
+  padding: 0;
+
+  width: 50%;
+
+  -webkit-animation-name: animatetop;
+  -webkit-animation-duration: 0.4s;
+  animation-name: animatetop;
+  animation-duration: 0.4s
+}
+
+/* Add Animation */
+@-webkit-keyframes animatetop {
+  from {top: -300px; opacity: 0}
+  to {top: 0; opacity: 1}
+}
+
+@keyframes animatetop {
+  from {top: -300px; opacity: 0}
+  to {top: 0; opacity: 1}
+}
+

--- a/src/tokenLookup.ts
+++ b/src/tokenLookup.ts
@@ -1,6 +1,6 @@
 import { SignedDevconTicket } from './Attestation/SignedDevonTicket';
 
-interface Item {
+export interface Item {
     onChain: any;
     tokenIssuerPublicKey?: any;
     title?: any;    
@@ -18,6 +18,8 @@ interface Item {
     tokenParser?: any;
     smartContractAddress?: any;
     symbol?: any;
+    base64senderPublicKey?: string;
+    base64attestorPubKey?: string;
 }
 
 interface TokenLookupInterface {
@@ -43,7 +45,19 @@ export const tokenLookup:TokenLookupInterface = {
         itemStorageKey: 'dcTokens',
         ethKeyitemStorageKey: 'dcEthKeys',
         emblem: 'https://raw.githubusercontent.com/TokenScript/token-negotiator/main/mock-images/devcon.svg',
-        tokenParser: SignedDevconTicket
+        tokenParser: SignedDevconTicket,
+        base64senderPublicKey: '-----BEGIN PUBLIC KEY-----\n' +
+            'MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA////////////////\n' +
+            '/////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n' +
+            'AAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5m\n' +
+            'fvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0\n' +
+            'SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFB\n' +
+            'AgEBA0IABJUMfAvtI8PKxcwxu7mq2btVMjh4gmcKwrHN8HmasOvHZMJn9wTo/doH\n' +
+            'lquDl6TSEBAk0kxO//aVs6QX8u0OSM0=\n' +
+            '-----END PUBLIC KEY-----',
+        base64attestorPubKey:
+        // stage.attestation.id public key
+            "MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBA0IABL+y43T1OJFScEep69/yTqpqnV/jzONz9Sp4TEHyAJ7IPN9+GHweCX1hT4OFxt152sBN3jJc1s0Ymzd8pNGZNoQ=",
     },
     "devcon-remote": {
         onChain: false,


### PR DESCRIPTION
Hey @nicktaras,

These commits aim to move integration logic out of the authenticator.js library and into TN.

In detail:
1. Move attestation postMessage functionality out of authenticator.js library and into auth-handler.ts. 
2. Create a mechanism to show iframe modal in client when requested by attestation.id. Outlet will make the iframe visible and pass a response back to the client to show its iframe in a modal.

I think a lot of this functionality could be consolidated in the messaging.ts class eventually but this is a good intermediate step, as it allows errors from attestation.id to flow back to the client and show in the popup. 