### PR TITLE
156 token negotiator unit tests uplift

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,11 @@ module.exports = {
     '!src/vendor/**'
   ],
   coverageDirectory: '<rootDir>/reports/coverage/',
+  coverageThreshold: {
+    global: {
+      lines: 26
+    }
+  },
   testPathIgnorePatterns: [
     "dist"
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   transform: {
     '^.+\\.(ts|tsx)?$': 'ts-jest',
-    "^.+\\.(js|jsx)$": "babel-jest",
+    "^.+\\.(js|jsx)$": '<rootDir>/test/jest/jest.transform.js'
   },
+  setupFilesAfterEnv: ['<rootDir>/test/jest/jest.setup.js'],
   reporters: ['default', 'jest-junit'],
   roots: ['<rootDir>/src'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
@@ -11,6 +12,10 @@ module.exports = {
   verbose: true,
   testTimeout: 300000,
   collectCoverage: true,
+  collectCoverageFrom: [
+    'src/**',
+    '!src/vendor/**'
+  ],
   coverageDirectory: '<rootDir>/reports/coverage/',
   testPathIgnorePatterns: [
     "dist"
@@ -22,6 +27,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/test/jest/__mocks__/mock.js'
-  }
+  },
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!@toruslabs/torus-embed)/']
 };
- 

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
   coverageDirectory: '<rootDir>/reports/coverage/',
   coverageThreshold: {
     global: {
-      lines: 29
+      lines: 30
     }
   },
   testPathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
   coverageDirectory: '<rootDir>/reports/coverage/',
   coverageThreshold: {
     global: {
-      lines: 26
+      lines: 29
     }
   },
   testPathIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenscript/token-negotiator",
-  "version": "1.0.10-alpha",
+  "version": "1.0.13-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenscript/token-negotiator",
-      "version": "1.0.10-alpha",
+      "version": "1.0.13-alpha",
       "license": "MIT",
       "dependencies": {
         "@tokenscript/attestation": "^1.0.7-alpha",

--- a/src/client/__tests__/client.spec.ts
+++ b/src/client/__tests__/client.spec.ts
@@ -3,40 +3,40 @@ import { Client } from "./../index";
 
 describe('client spec', () => {
 
-  test('placeholder test', () => { expect(1).toEqual(1) });
+  test('tokenNegotiatorClient a new instance of client', () => {
+    const tokenNegotiatorClient = new Client({
+      type: "active",
+      issuers: [
+        "devcon"
+      ],
+      options: {}
+    });
+    expect(tokenNegotiatorClient.issuers).toEqual(["devcon"]);
+  });
 
-  // test('tokenNegotiatorClient a new instance of client', () => {
-  //   const tokenNegotiatorClient = new Client({
-  //     type: "active",
-  //     issuers: [
-  //       "devcon"
-  //     ],
-  //     options: {}
-  //   });
-  //   expect(tokenNegotiatorClient.issuers).toEqual(["devcon"]);
-  // });
-
-  // test('tokenNegotiatorClient a failed new instance of client - missing issuers', () => {
-  //   expect(() => {
-  //     new Client({
-  //       type: 'passive',
-  //       options: {}
-  //     })
-  //   }).toThrow('issuers are missing.');
-  // });
+  test('tokenNegotiatorClient a failed new instance of client - missing issuers', () => {
+    expect(() => {
+      new Client({
+        type: 'passive',
+        options: {}
+      })
+    }).toThrow('issuers are missing.');
+  });
   
-  // test('tokenNegotiatorClient a failed new instance of client - missing type', () => {
-  //   expect(() => {
-  //     new Client({
-  //       type: undefined,
-  //       issuers: [
-  //         "devcon"
-  //       ],
-  //       options: {}
-  //     })
-  //   }).toThrow('type is required.');
-  // });
+  test('tokenNegotiatorClient a failed new instance of client - missing type', () => {
+    expect(() => {
+      new Client({
+        type: undefined,
+        issuers: [
+          "devcon"
+        ],
+        options: {}
+      })
+    }).toThrow('type is required.');
+  });
 
+  // NOTE: As of 20-apr-2022 addTokenThroughIframe method no longer exists
+  //
   // test('tokenNegotiatorClient to connect Metamask And Get Address with window eth', async () => {
   //   window.ethereum = () => {};
   //   const tokenNegotiatorClient = new Client({

--- a/src/client/__tests__/client.spec.ts
+++ b/src/client/__tests__/client.spec.ts
@@ -1,17 +1,44 @@
 // @ts-nocheck
 import { Client } from "./../index";
 
+function getSimpleClient() {
+  return new Client({
+    type: "active",
+    issuers: [
+      "devcon"
+    ]
+  });
+}
+
 describe('client spec', () => {
 
   test('tokenNegotiatorClient a new instance of client', () => {
+    const tokenNegotiatorClient = getSimpleClient();
+    expect(tokenNegotiatorClient.issuers).toEqual(["devcon"]);
+  });
+
+  test('tokenNegotiatorClient with valid contract and chain', () => {
     const tokenNegotiatorClient = new Client({
       type: "active",
       issuers: [
-        "devcon"
+        { collectionID: "bayc", contract: '0x26472AA24D795AbcB687bddb44d733ef55Ebdf09', chain: 'rinkeby' }
       ],
       options: {}
     });
-    expect(tokenNegotiatorClient.issuers).toEqual(["devcon"]);
+    expect(tokenNegotiatorClient.issuers[0].chain).toEqual('rinkeby');
+  });
+
+  test('tokenNegotiatorClient duplicate collectionID is ignored', () => {
+    const tokenNegotiatorClient = new Client({
+      type: "active",
+      issuers: [
+        { collectionID: "bayc", contract: '0x26472AA24D795AbcB687bddb44d733ef55Ebdf09', chain: 'rinkeby' },
+        { collectionID: "bayc", contract: '0x26472AA24D795AbcB687bddb44d733ef55Ebdf09', chain: 'mainnet' }
+      ],
+      options: {}
+    });
+    expect(tokenNegotiatorClient.issuers[0].chain).toEqual('rinkeby');
+    expect(tokenNegotiatorClient.onChainTokens.tokenKeys.length).toBe(1);
   });
 
   test('tokenNegotiatorClient a failed new instance of client - missing issuers', () => {
@@ -22,7 +49,7 @@ describe('client spec', () => {
       })
     }).toThrow('issuers are missing.');
   });
-  
+
   test('tokenNegotiatorClient a failed new instance of client - missing type', () => {
     expect(() => {
       new Client({
@@ -33,6 +60,22 @@ describe('client spec', () => {
         options: {}
       })
     }).toThrow('type is required.');
+  });
+
+  test('tokenNegotiatorClient on callback with event type tokens-selected ', () => {
+    const tokenNegotiatorClient = getSimpleClient();
+    const event = 'tokens-selected';
+    tokenNegotiatorClient.on(event, () => {
+      console.log(event)
+    });
+    expect(tokenNegotiatorClient.clientCallBackEvents[event]).toBeDefined();
+  });
+
+  test('tokenNegotiatorClient on callback must have an event type', () => {
+    const tokenNegotiatorClient = getSimpleClient();
+    expect(() => {
+      tokenNegotiatorClient.on('')
+    }).toThrow('Event type is not defined');
   });
 
   // NOTE: As of 20-apr-2022 addTokenThroughIframe method no longer exists

--- a/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
+++ b/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
@@ -1,5 +1,22 @@
 import { OnChainTokenModule } from "../index";
 
+function mockFetch(data: any) {
+  return jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => data
+    })
+  );
+}
+
+interface ContractAddressMetaData {
+  api?: string,
+  chain: string,
+  contractAddress: string,
+  title: string,
+  image: string
+}
+
 describe('On-chain token module', () => {
 
   test('getOnChainAPISupportBool should be true for supported APIs and chains', () => {
@@ -12,6 +29,81 @@ describe('On-chain token module', () => {
     const token = new OnChainTokenModule();
     expect(token.getOnChainAPISupportBool('nosuchapi', 'eth')).toBe(false);
     expect(token.getOnChainAPISupportBool('opensea', 'nosuchchain')).toBe(false);
+  });
+
+  test('getInitialContractAddressMetaData should return OpenSea data', async () => {
+    const mockOpenSeaResponse = {
+      assets: [
+        {
+          collection: {
+            image_url: 'https://rinkeby-api.opensea.io/api/v1/assets?asset_contract_address=0x88b48f654c30e99bc2e4a1559b4dcf1ad93fa656&collection=stl-rnd-zed&order_direction=desc&offset=0&limit=20',
+            name: 'STL RnD Zed'
+          }
+        }
+      ]
+    }
+    global.fetch = mockFetch(mockOpenSeaResponse);
+    const token = new OnChainTokenModule();
+    const issuer =
+      { contract: '0x88b48f654c30e99bc2e4a1559b4dcf1ad93fa656', chain: 'rinkeby', openSeaSlug: 'stl-rnd-zed' }
+    const metaData = await token.getInitialContractAddressMetaData(issuer) as ContractAddressMetaData;
+    // expect(metaData.api).toBe('opensea'); // api property is not currently returned for OpenSea
+    expect(metaData.chain).toBe(issuer.chain);
+    expect(metaData.contractAddress).toBe(issuer.contract);
+    expect(metaData.title).toBe(mockOpenSeaResponse.assets[0].collection.name);
+    expect(metaData.image).toBe(mockOpenSeaResponse.assets[0].collection.image_url);
+  });
+
+  test('getInitialContractAddressMetaData should return Moralis data', async () => {
+    const image = 'https://qaimages.lysto.io/assets/bxrt5/token-book.png';
+    const mockMoralisResponse = {
+      result: [
+        {
+          metadata: `{"name":"Membership Token #1","description":"Get Exclusive access to membership club for this NFT","image":"${image}"}`,
+          name: 'MaticTest01'
+        }
+      ]
+    }
+    global.fetch = mockFetch(mockMoralisResponse);
+    const token = new OnChainTokenModule();
+    const issuer =
+      { contract: '0x94683E532AA9e5b47EF86bBb2D43b768C76c6C19', chain: 'polygon' }
+    const metaData = await token.getInitialContractAddressMetaData(issuer) as ContractAddressMetaData;
+    expect(metaData.api).toBe('moralis');
+    expect(metaData.chain).toBe(issuer.chain);
+    expect(metaData.contractAddress).toBe(issuer.contract);
+    expect(metaData.title).toBe(mockMoralisResponse.result[0].name);
+    expect(metaData.image).toBe(image);
+  });
+
+  test('getInitialContractAddressMetaData should return Alchemy data', async () => {
+    const alchemyResponse = {
+      nfts: [
+        {
+          metadata: {
+            image: 'https://theinternet.com/alchemy-nft.jpg',
+          },
+          title: 'Alchemy NFT'
+        }
+      ]
+    }
+    global.fetch = mockFetch( alchemyResponse);
+    const token = new OnChainTokenModule();
+    const issuer =
+      { contract: '0x94683E532AA9e5b47EF86bBb2D43b768C76c6C19', chain: 'optimism' } // Chain not supported on Moralis, ensuring Alchemy is used
+    const metaData = await token.getInitialContractAddressMetaData(issuer) as ContractAddressMetaData;
+    expect(metaData.api).toBe('alchemy');
+    expect(metaData.chain).toBe(issuer.chain);
+    expect(metaData.contractAddress).toBe(issuer.contract);
+    expect(metaData.title).toBe(alchemyResponse.nfts[0].title);
+    expect(metaData.image).toBe(alchemyResponse.nfts[0].metadata.image);
+  });
+
+  test('getInitialContractAddressMetaData should return undefined for unrecognised issuer', async () => {
+    const token = new OnChainTokenModule();
+    const issuer =
+      { contract: '0x88b48f654c30e99bc2e4a1559b4dcf1ad93fa656', chain: 'nosuchchain', openSeaSlug: 'stl-rnd-zed' }
+    expect(await token.getInitialContractAddressMetaData(issuer)).toBe(undefined);
   });
 
 });

--- a/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
+++ b/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
@@ -1,0 +1,17 @@
+import { OnChainTokenModule } from "../index";
+
+describe('On-chain token module', () => {
+
+  test('getOnChainAPISupportBool should be true for supported APIs and chains', () => {
+    const token = new OnChainTokenModule();
+    expect(token.getOnChainAPISupportBool('opensea', 'eth')).toBe(true);
+    expect(token.getOnChainAPISupportBool('alchemy', 'polygon')).toBe(true);
+  });
+
+  test('getOnChainAPISupportBool should be false for unsupported APIs and chains', () => {
+    const token = new OnChainTokenModule();
+    expect(token.getOnChainAPISupportBool('nosuchapi', 'eth')).toBe(false); // throws exception
+    expect(token.getOnChainAPISupportBool('opensea', 'nosuchchain')).toBe(false); // returns true
+  });
+
+});

--- a/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
+++ b/src/onChainTokenModule/__tests__/onchaintoken.spec.ts
@@ -10,8 +10,8 @@ describe('On-chain token module', () => {
 
   test('getOnChainAPISupportBool should be false for unsupported APIs and chains', () => {
     const token = new OnChainTokenModule();
-    expect(token.getOnChainAPISupportBool('nosuchapi', 'eth')).toBe(false); // throws exception
-    expect(token.getOnChainAPISupportBool('opensea', 'nosuchchain')).toBe(false); // returns true
+    expect(token.getOnChainAPISupportBool('nosuchapi', 'eth')).toBe(false);
+    expect(token.getOnChainAPISupportBool('opensea', 'nosuchchain')).toBe(false);
   });
 
 });

--- a/src/onChainTokenModule/index.ts
+++ b/src/onChainTokenModule/index.ts
@@ -43,8 +43,8 @@ export class OnChainTokenModule {
         // TODO add support XDAI.
         // https://www.xdaichain.com/for-developers/developer-resources/ankr-api
 
-        return apiBlockchainSupport[apiName].indexOf(chain) >= -1;
-
+        if (!(apiName in apiBlockchainSupport)) return false;
+        return apiBlockchainSupport[apiName].indexOf(chain) >= 0;
     }
 
     /**

--- a/src/outlet/__tests__/outlet.spec.ts
+++ b/src/outlet/__tests__/outlet.spec.ts
@@ -1,0 +1,19 @@
+import { Outlet } from '../index';
+
+/*
+  TODO: Find a solution for TypeError: Cannot convert a BigInt value to a number at Math.pow (<anonymous>)
+  Thrown by import {Authenticator} from '@tokenscript/attestation' due to @tokenscript/attestation/src/libs/Point.ts
+*/
+
+describe('Outlet spec', () => {
+
+  test('placeholder test', () => {
+      expect(true).toBe(true);
+  });
+
+//   test('Create outlet from token name', () => {
+//     const outlet = new Outlet({ config: {tokenName: 'devcon-remote'}});
+//     console.log(outlet);
+//   });
+
+});

--- a/test/jest/__mocks__/mock.js
+++ b/test/jest/__mocks__/mock.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = {}; // eslint-disable-line

--- a/test/jest/jest.setup.js
+++ b/test/jest/jest.setup.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line no-undef
 jest.spyOn(global.console, 'error').mockImplementation((message) => {
   if (!message.toString().startsWith('ReferenceError: fetch is not defined')) {
     throw new Error(`Unexpected console.error: ${message}`);
-  }  
+  }
 });

--- a/test/jest/jest.setup.js
+++ b/test/jest/jest.setup.js
@@ -1,0 +1,5 @@
+jest.spyOn(global.console, 'error').mockImplementation((message) => {
+  if (!message.toString().startsWith('ReferenceError: fetch is not defined')) {
+    throw new Error(`Unexpected console.error: ${message}`);
+  }  
+});

--- a/test/jest/jest.transform.js
+++ b/test/jest/jest.transform.js
@@ -3,4 +3,6 @@ const babelOptions = {
         'allowReturnOutsideFunction': true
     },
 };
+
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
 module.exports = require('babel-jest').default.createTransformer(babelOptions);

--- a/test/jest/jest.transform.js
+++ b/test/jest/jest.transform.js
@@ -1,0 +1,6 @@
+const babelOptions = {
+    parserOpts: {
+        'allowReturnOutsideFunction': true
+    },
+};
+module.exports = require('babel-jest').default.createTransformer(babelOptions);


### PR DESCRIPTION
**Test updates and additions**

- Re-enabled the Client tests. The tests themselves did not require any code changes, but several jest configuration customisations were required due to the Torus dependencies. The last test for `addTokenThroughIframe` has been left commented out since that function does not exist.
- Added several new client tests.
- Added tests for OnChainTokenModule. Includes mocking of contract API fetch requests.
- Attempted to add a test for Outlet but hit an issue with a TypeError in `@tokenscript/attestation`. Left in as a placeholder test with a TODO comment.

**Bugs**

As a result of writing the tests for OnChainTokenModule two bugs were found in the `getOnChainAPISupportBool`. They have been fixed by this PR. Note that this function always returned true for any chain value.

**Code coverage**

The original code coverage figures were misleading since only modules with tests were reported. The jest configuration has been updated to include all folders in `src` except `vendor`.

Coverage before and after adding tests:
Statements: 12.3 -> 30.3
Branch: 10.42 -> 15.36
Functions: 9.23 -> 21.92
Lines: **11.29** -> **30.12**

The jest config `coverageThreshold` has been added and set to 30 lines to ensure no regression. This value can be increased as new tests are added.