### PR TITLE
Fix tab messaging for safari browser.

### DIFF
--- a/src/client/messaging.ts
+++ b/src/client/messaging.ts
@@ -41,6 +41,7 @@ export enum MessageResponseAction {
 declare global {
     interface Window {
         NEGOTIATOR_DEBUG: boolean;
+        safari?: any
     }
 }
 
@@ -55,8 +56,13 @@ export class Messaging {
 
     async sendMessage(request:MessageRequestInterface, forceTab:boolean = false){
 
-        if (!forceTab && this.iframeStorageSupport === null)
-            this.iframeStorageSupport = await this.thirdPartyCookieSupportCheck(request.origin);
+        if (!forceTab && this.iframeStorageSupport === null) {
+            if (window.safari){
+                this.iframeStorageSupport = false;
+            } else {
+                this.iframeStorageSupport = await this.thirdPartyCookieSupportCheck(request.origin);
+            }
+        }
 
         // Uncomment to test popup mode
         //this.iframeStorageSupport = false;
@@ -169,7 +175,7 @@ export class Messaging {
         attachPostMessageListener(listener);
 
         if (timeout == undefined)
-            timeout = 25000;
+            timeout = 10000;
 
         if (timeout > 0)
             timer = setTimeout(()=>{
@@ -229,7 +235,7 @@ export class Messaging {
                 this.setResponseListener(
                     id,
                     origin,
-                    25000,
+                    10000,
                     (responseData:any)=>{
                         resolve(!!responseData.thirdPartyCookies);
                     },

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -67,10 +67,6 @@ export class Outlet {
     console.log("Outlet received event ID " + evtid + " action " + action);
     // Outlet Page OnLoad Event Handler
 
-    // store local storage item that can be later used to check if third party cookies are allowed.
-    // Note: This test can only be performed when the localstorage / cookie is assigned, then later requested.
-    localStorage.setItem('cookie-support-check', 'test');
-
     // TODO: should issuer be validated against requested issuer?
 
     switch (action) {
@@ -102,6 +98,10 @@ export class Outlet {
         break;
 
       default:
+
+        // store local storage item that can be later used to check if third party cookies are allowed.
+        // Note: This test can only be performed when the localstorage / cookie is assigned, then later requested.
+        localStorage.setItem('cookie-support-check', 'test');
 
         const { tokenUrlName, tokenSecretName, tokenIdName, itemStorageKey } = this.tokenConfig;
 


### PR DESCRIPTION
@nicktaras small patch to fix Safari support. 

Since this is always a restriction in safari I decided to check for Safari directly rather than use the local storage check. 
Other browsers still use the iframe cookie check in case they're using stricter privacy controls. 