### PR TITLE
Fix alphawallet browser android tab behaviour TKN-252

### DIFF
--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -38,8 +38,7 @@ export class Messaging {
 	async sendMessage(request: RequestInterfaceBase, forceTab = false): Promise<ResponseInterfaceBase> {
 
 		if (!forceTab && this.iframeStorageSupport === null) {
-			if (window.safari)
-				this.iframeStorageSupport = false;
+			this.iframeStorageSupport = !window.safari;
 		}
 
 		// Uncomment to test popup mode
@@ -140,11 +139,11 @@ export class Messaging {
 						if (!iframe || this.iframeStorageSupport === true)
 							return;
 
-						this.iframeStorageSupport = !!response?.data?.thirdPartyCookies;
+						/* this.iframeStorageSupport = !!response?.data?.thirdPartyCookies;
 						if (!this.iframeStorageSupport){
 							afterResolveOrError();
 							reject("IFRAME_STORAGE");
-						}
+						}*/
 						return;
 					}
 

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -38,7 +38,8 @@ export class Messaging {
 	async sendMessage(request: RequestInterfaceBase, forceTab = false): Promise<ResponseInterfaceBase> {
 
 		if (!forceTab && this.iframeStorageSupport === null) {
-			this.iframeStorageSupport = !window.safari;
+			// iframe local storage access from other origins is not available in safari & ios UIWebView
+			this.iframeStorageSupport = !(window.safari || /(iphone|ipod|ipad).*applewebkit/.test(window.navigator.userAgent.toLowerCase()));
 		}
 
 		// Uncomment to test popup mode

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -38,8 +38,7 @@ export class Messaging {
 	async sendMessage(request: RequestInterfaceBase, forceTab = false): Promise<ResponseInterfaceBase> {
 
 		if (!forceTab && this.iframeStorageSupport === null) {
-			// iframe local storage access from other origins is not available in safari & ios UIWebView
-			this.iframeStorageSupport = !(window.safari || /(iphone|ipod|ipad).*applewebkit/.test(window.navigator.userAgent.toLowerCase()));
+			this.iframeStorageSupport = !window.safari;
 		}
 
 		// Uncomment to test popup mode


### PR DESCRIPTION
The third party cookie check requires that the ticket is created in 
the outlet. This creates a special localStorage flag that can be checked 
via negotiator to infer cross-origin local storage access. 

The problem with this is that if the check fails, a popup is used automatically. 
This may happen when the ticket is not issued or on the ticket issuer page itself. 
Alphawallet android and many other dapp browsers do not support popups and instead 
navigate to the page in the same window. This causes a white screen with no way to return. 

This commit disables the check and only forces the use of tabs in browsers known to restrict 
iframe access to local storage, like safari:
https://stackoverflow.com/questions/63922558/safari-localstorage-not-shared-between-iframes-hosted-on-same-domain