### PR TITLE
feature: add support for safe-connect attestations via direct wallet connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.2.0",
-        "@tokenscript/attestation": "^0.3.9-sc.2",
+        "@tokenscript/attestation": "^0.3.9-sc.6",
         "@toruslabs/torus-embed": "^1.25.0",
         "@walletconnect/web3-provider": "^1.7.1",
         "ethers": "^5.4.0",
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@tokenscript/attestation": {
-      "version": "0.3.9-sc.2",
-      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.3.9-sc.2.tgz",
-      "integrity": "sha512-Zj9eP9BZQnq68Yh8g8OSSN3RS5m/E1fWG583gwcDfAN72MlHjy8DmotzSwQ3ll0asq0sq3auq120mCeE7cIi9Q==",
+      "version": "0.3.9-sc.6",
+      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.3.9-sc.6.tgz",
+      "integrity": "sha512-NlEjH5Uug0271l2sN6tlKunJYHD1fHOcMskjDf533na67KJqLuhJ293TykdOZtPbFjpfnrajZkcvbZDNTKliKQ==",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.1.6",
         "elliptic": "^6.5.3",
@@ -16724,9 +16724,9 @@
       }
     },
     "@tokenscript/attestation": {
-      "version": "0.3.9-sc.2",
-      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.3.9-sc.2.tgz",
-      "integrity": "sha512-Zj9eP9BZQnq68Yh8g8OSSN3RS5m/E1fWG583gwcDfAN72MlHjy8DmotzSwQ3ll0asq0sq3auq120mCeE7cIi9Q==",
+      "version": "0.3.9-sc.6",
+      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.3.9-sc.6.tgz",
+      "integrity": "sha512-NlEjH5Uug0271l2sN6tlKunJYHD1fHOcMskjDf533na67KJqLuhJ293TykdOZtPbFjpfnrajZkcvbZDNTKliKQ==",
       "requires": {
         "@peculiar/asn1-schema": "^2.1.6",
         "elliptic": "^6.5.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/TokenScript/token-negotiator#readme",
   "dependencies": {
     "@peculiar/asn1-schema": "^2.2.0",
-    "@tokenscript/attestation": "^0.3.9-sc.2",
+    "@tokenscript/attestation": "^0.3.9-sc.6",
     "@toruslabs/torus-embed": "^1.25.0",
     "@walletconnect/web3-provider": "^1.7.1",
     "ethers": "^5.4.0",

--- a/src/client/auth/util/SafeConnect.ts
+++ b/src/client/auth/util/SafeConnect.ts
@@ -1,0 +1,94 @@
+import {KeyStore} from "@tokenscript/attestation/dist/safe-connect/KeyStore";
+import {uint8tohex} from "@tokenscript/attestation/dist/libs/utils";
+import {EthereumKeyLinkingAttestation} from "@tokenscript/attestation/dist/safe-connect/EthereumKeyLinkingAttestation";
+
+export interface ChallengeInterface {
+	expiry: number;
+	messageToSign: string;
+	address: string;
+	signature?: string;
+}
+
+export interface ProofRequestInterface {
+	type: string;
+	subject: string;
+	signature: string;
+	address: string;
+	data?: any;
+}
+
+export interface ProofResponseInterface {
+	type: string;
+	expiry: number;
+	data?: any;
+}
+
+export class SafeConnect {
+
+	public static HOLDING_KEY_ALGORITHM = "RSASSA-PKCS1-v1_5";
+
+	public static keyStore = new KeyStore();
+
+	public static async getLinkPrivateKey(){
+		let keys = await SafeConnect.keyStore.getOrCreateKey(SafeConnect.HOLDING_KEY_ALGORITHM);
+		return keys.attestHoldingKey.privateKey;
+	}
+
+	public static async getLinkPublicKey(){
+		let keys = await SafeConnect.keyStore.getOrCreateKey(SafeConnect.HOLDING_KEY_ALGORITHM);
+		return uint8tohex(keys.holdingPubKey);
+	}
+
+	public static async getChallenge(safeConnectUrl: string, address: string){
+		try {
+			return await this.apiRequest(safeConnectUrl, "POST", "get-challenge", { address: address }) as ChallengeInterface
+		} catch (e) {
+			throw new Error("Failed to get address challenge: " + e.message);
+		}
+	}
+
+	public static async getAttestation(safeConnectUrl: string, serverPayload: ProofRequestInterface){
+		try {
+			return await this.apiRequest(safeConnectUrl, "POST", "issue-attestation", serverPayload) as ProofResponseInterface;
+		} catch (e) {
+			throw new Error("Failed to get address attestation: " + e.message);
+		}
+	}
+
+	private static async apiRequest(url: string, method: string, path: string, data?: any){
+
+		let res = await fetch(url + "api/" + path, {
+			method: method,
+			body: JSON.stringify(data),
+			credentials: 'include',
+			headers: {
+				"Content-Type": "application/json"
+			}
+		});
+
+		if (res.status > 299 || res.status < 200) {
+			let msg;
+
+			try {
+				msg = (await res.json()).error;
+			} catch (e){
+				msg = "HTTP Request error: " + res.statusText;
+			}
+
+			throw new Error(msg);
+		}
+
+		return await res.json();
+	}
+
+	public static async createAndSignLinkAttestation(addressAttest: string, linkedEthAddress: string, holdingPrivKey: CryptoKey){
+
+		const linkAttest = new EthereumKeyLinkingAttestation();
+
+		linkAttest.create(addressAttest, linkedEthAddress, 3600);
+
+		await linkAttest.sign(holdingPrivKey);
+
+		return linkAttest.getBase64();
+	}
+}


### PR DESCRIPTION
@nicktaras This PR adds support for using safe-connect attestations when the user has used a direct wallet connection. This will later be used to add NFT attestation authentication to the shopify app, and move away from UN signature auth.