### PR TITLE
chore: 🤖 remove dist/ from repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Token-negotiator a token attestation bridge between web 2.0 and 3.0.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist/"],
   "scripts": {
     "build": "npm run clean && tsc --outDir dist && npm run copy-assets",
     "build-umd": "shx rm -rf token-negotiator-dist && webpack && npm run copy-assets-umd",
     "clean": "shx rm -rf dist",
     "copy-assets": "copyfiles ./src/theme/*.css dist/theme -V --flat && copyfiles ./src/vendor/*.js dist/vendor -V --flat",
     "copy-assets-umd": "copyfiles ./src/theme/*.css token-negotiator-dist/theme -V --flat && copyfiles ./src/vendor/*.js token-negotiator-dist/vendor -V --flat",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "lint": "eslint . --quiet",
     "test": "jest",
     "test-watch": "jest --watch"


### PR DESCRIPTION
Remove `dist/` from repo, this will generate by `npm run build` job.

And I replace `prepublishOnly` task with `prepare`, which will automatically run after `npm ci/install`, and run before `npm pack/publish`. See: https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish

So both `npm publish` and `npm install "git://github.com/tokenScript/token-negotiator.git#staging"` should work.

And I set `"files": ["dist/"]` in `package.json`, which will limit npm package only contains `dist/` directory and `package.json`.

After all, this should fix CI https://github.com/TokenScript/token-negotiator-examples/pull/96