### PR TITLE
Fix: error type handling

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -109,10 +109,31 @@ export const waitForElementToExist = (selector: string): Promise<Element> => {
 
 export type ErrorType = 'warning' | 'info' | 'error';
 
-export const errorHandler = (message: string, type: ErrorType, action?: Function | null, data?: unknown, log = true, throwError = false) => {
-	if (log) logger(2, type + ': ' + message);
+export const errorHandler = (error: any, type: ErrorType, action?: Function | null, data?: unknown, log = true, throwError = false) => {
+
+	let errorMsg;
+
+	if (typeof error === "object"){
+		errorMsg = error.message ?? {};
+	} else {
+		errorMsg = error;
+	}
+
+	if (log) logger(2, type + ': ' + errorMsg);
+
 	if (action) action();
-	if (throwError) throw new Error(message);
-	return {type, message, data}
+
+	if (throwError) {
+		throw new NegotiatorError(errorMsg, error);
+	}
+
+	return {type, message: error, data}
+}
+
+export class NegotiatorError extends Error {
+
+	constructor(message: string, public originalError: {}|string, public code?: string) {
+		super(message);
+	}
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -114,7 +114,7 @@ export const errorHandler = (error: any, type: ErrorType, action?: Function | nu
 	let errorMsg;
 
 	if (typeof error === "object"){
-		errorMsg = error.message ?? {};
+		errorMsg = error.message ?? "Unknown error type: " + JSON.stringify(error);
 	} else {
 		errorMsg = error;
 	}
@@ -132,7 +132,7 @@ export const errorHandler = (error: any, type: ErrorType, action?: Function | nu
 
 export class NegotiatorError extends Error {
 
-	constructor(message: string, public originalError: {}|string, public code?: string) {
+	constructor(message: string, public originalError: any, public code?: string) {
 		super(message);
 	}
 }


### PR DESCRIPTION
This PR addresses issues with error handling to correct cases where the error provided is an Error type or other object. 
This resulted in [object Object] being shown in the UI and the original error message being lost. 

A new error type has been created to wrap the original error and provide a human readable message in all cases. 
This new type could also be used to categorize errors with an error code to provide more user friendly messages.