### PR TITLE
Feature: custom view factory

### DIFF
--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -2,7 +2,7 @@ import {Start} from './views/start';
 
 import {logger, requiredParams} from "../utils";
 import {Client, ClientError} from "./index";
-import {ViewInterface, ViewConstructor} from "./views/view-interface";
+import {ViewInterface, ViewFactory, ViewConstructor} from "./views/view-interface";
 import {TokenStore} from "./tokenStore";
 import {SelectIssuers} from "./views/select-issuers";
 import {SelectWallet} from "./views/select-wallet";
@@ -23,14 +23,14 @@ export interface UIOptionsInterface {
 	autoPopup?: boolean;
 	alwaysShowStartScreen?: boolean;
 	viewOverrides?: {
-		[type: string]: ViewConstructor<ViewInterface>
+		[type: string]: ViewFactory
 	}
 }
 
 export interface UiInterface {
 	viewContainer: HTMLElement,
 	initialize(): void;
-	updateUI(ViewClass: ViewConstructor<ViewInterface>|ViewType, data?: any);
+	updateUI(ViewClass: ViewFactory|ViewType, data?: any);
 	closeOverlay(): void;
 	openOverlay(): void;
 	togglePopup(): void;
@@ -72,6 +72,8 @@ export class Ui implements UiInterface {
 	currentView: ViewInterface|undefined;
 	retryCallback?: Function;
 	retryButton: any;
+
+	private isStartView = true;
 
 	constructor(options: UIOptionsInterface, client: Client) {
 		this.options = options;
@@ -118,31 +120,37 @@ export class Ui implements UiInterface {
 
 	}
 
-	public getViewClass(type: ViewType): ViewConstructor<ViewInterface> {
+	public getViewFactory(type: ViewType): ViewFactory {
 
 		if (this.options.viewOverrides?.[type])
 			return this.options.viewOverrides?.[type];
 
 		switch (type){
 		case "start":
-			return Start;
+			return this.getDefaultViewFactory(Start);
 		case "main":
-			return SelectIssuers;
+			return this.getDefaultViewFactory(SelectIssuers);
 		case "wallet":
-			return SelectWallet;
+			return this.getDefaultViewFactory(SelectWallet);
+		}
+	}
+
+	private getDefaultViewFactory(viewContructor: ViewConstructor<ViewInterface>){
+		return (client: Client, popup: Ui, viewContainer: any, params: any) => {
+			return new viewContructor(client, popup, viewContainer, params);
 		}
 	}
 
 	public async getStartScreen(){
 
 		if (this.options.alwaysShowStartScreen || !localStorage.getItem(TokenStore.LOCAL_STORAGE_KEY) || !this.client.getTokenStore().getTotalTokenCount())
-			return this.getViewClass("start");
+			return "start";
 
 		if (await this.canSkipWalletSelection()){
 			this.client.enrichTokenLookupDataOnChainTokens();
-			return this.getViewClass("main");
+			return "main";
 		} else {
-			return this.getViewClass("wallet");
+			return "wallet";
 		}
 	}
 
@@ -231,23 +239,27 @@ export class Ui implements UiInterface {
 		}
 	}
 
-	updateUI(ViewClass: ViewConstructor<ViewInterface>|ViewType, data?: any) {
+	updateUI(viewFactory: ViewFactory|ViewType, data?: any) {
 
-		if (typeof ViewClass === "string")
-			ViewClass = this.getViewClass(ViewClass);
+		if (typeof viewFactory === "string") {
+			this.isStartView = viewFactory === "start";
+			viewFactory = this.getViewFactory(viewFactory);
+		} else {
+			this.isStartView = false;
+		}
 
 		if (!this.viewContainer){
 			logger(3, "Element .overlay-content-tn not found: popup not initialized");
 			return;
 		}
 
-		this.currentView = new ViewClass(this.client, this, this.viewContainer, {options: this.options, data: data});
+		this.currentView = viewFactory(this.client, this, this.viewContainer, {options: this.options, data: data});
 		this.currentView.render();
 
 	}
 
 	viewIsNotStart(){
-		return !(this.currentView instanceof this.getViewClass("start"));
+		return !this.isStartView;
 	}
 
 	showError(error: string | Error, canDismiss = true){

--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -23,7 +23,7 @@ export interface UIOptionsInterface {
 	autoPopup?: boolean;
 	alwaysShowStartScreen?: boolean;
 	viewOverrides?: {
-		[type: string]: ViewFactory
+		[type: string]: ViewFactory|ViewConstructor<ViewInterface>
 	}
 }
 
@@ -120,24 +120,18 @@ export class Ui implements UiInterface {
 
 	}
 
-	public getViewFactory(type: ViewType): ViewFactory {
+	public getViewFactory(type: ViewType): ViewFactory|ViewConstructor<ViewInterface> {
 
 		if (this.options.viewOverrides?.[type])
 			return this.options.viewOverrides?.[type];
 
 		switch (type){
 		case "start":
-			return this.getDefaultViewFactory(Start);
+			return Start;
 		case "main":
-			return this.getDefaultViewFactory(SelectIssuers);
+			return SelectIssuers;
 		case "wallet":
-			return this.getDefaultViewFactory(SelectWallet);
-		}
-	}
-
-	private getDefaultViewFactory(viewContructor: ViewConstructor<ViewInterface>){
-		return (client: Client, popup: Ui, viewContainer: any, params: any) => {
-			return new viewContructor(client, popup, viewContainer, params);
+			return SelectWallet;
 		}
 	}
 
@@ -239,7 +233,7 @@ export class Ui implements UiInterface {
 		}
 	}
 
-	updateUI(viewFactory: ViewFactory|ViewType, data?: any) {
+	updateUI(viewFactory: ViewFactory|ViewConstructor<ViewInterface>|ViewType, data?: any) {
 
 		if (typeof viewFactory === "string") {
 			this.isStartView = viewFactory === "start";
@@ -253,7 +247,9 @@ export class Ui implements UiInterface {
 			return;
 		}
 
-		this.currentView = viewFactory(this.client, this, this.viewContainer, {options: this.options, data: data});
+		// @ts-ignore
+		this.currentView = new viewFactory(this.client, this, this.viewContainer, {options: this.options, data: data});
+
 		this.currentView.render();
 
 	}

--- a/src/client/views/view-interface.ts
+++ b/src/client/views/view-interface.ts
@@ -5,6 +5,8 @@ export interface ViewConstructor<T> {
 	new (client: Client, popup: Ui, viewContainer: any, params: any): T;
 }
 
+export type ViewFactory = (client: Client, popup: Ui, viewContainer: any, params: any) => ViewInterface;
+
 export interface ViewInterface {
 	render(): void;
 	init(): void;


### PR DESCRIPTION
Using a class (constructor) in the config has the limitation that no external dependencies can be injected into the class, 
since the ViewConstructor<ViewInterface> has a static constructor.

This updates the option to use a factory pattern to allow external dependency injection into overridden views. 

It would be possible, but not future proof to allow the config to accept a factory function and a class constructor 
but there is no official and robust way to determine which one the parameter is at runtime. 