### PR TITLE
fix: specify "any" network for WC & Torus ethers instance

### DIFF
--- a/src/wallet/Web3WalletProvider.ts
+++ b/src/wallet/Web3WalletProvider.ts
@@ -246,7 +246,7 @@ export class Web3WalletProvider {
 			}
 
 			walletConnect.enable().then(() => {
-				const provider = new ethers.providers.Web3Provider(walletConnect);
+				const provider = new ethers.providers.Web3Provider(walletConnect, "any");
 
 				resolve(this.registerProvider(provider, "WalletConnect"));
 			}).catch((e) => reject(e));
@@ -265,7 +265,7 @@ export class Web3WalletProvider {
 
 		await torus.login();
 
-		const provider = new ethers.providers.Web3Provider(torus.provider);
+		const provider = new ethers.providers.Web3Provider(torus.provider, "any");
 
 		return this.registerProvider(provider, "Torus");
 


### PR DESCRIPTION
@nicktaras I forgot to add the "any" chain parameter to WC and Torus ethers instances