### PR TITLE
fix: use UMD modules for Torus & WalletConnect to fix polyfill issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tokenscript/token-negotiator",
   "version": "2.2.0",
   "description": "Token-negotiator a token attestation bridge between web 2.0 and 3.0.",
-  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/"

--- a/src/wallet/TorusProvider.ts
+++ b/src/wallet/TorusProvider.ts
@@ -1,5 +1,5 @@
-import Torus from "@toruslabs/torus-embed";
+import Torus from "@toruslabs/torus-embed/dist/torus.umd.min";
 
 export const getTorusProviderInstance = async () => {
-  return new Torus();
+	return new Torus();
 }

--- a/src/wallet/WalletConnectProvider.ts
+++ b/src/wallet/WalletConnectProvider.ts
@@ -1,4 +1,4 @@
-import WalletConnectProvider from "@walletconnect/web3-provider";
+import WalletConnectProvider from "@walletconnect/web3-provider/dist/umd/index.min";
 
 export const getWalletConnectProviderInstance = async (checkConnectionOnly?: boolean) => {
 	return new WalletConnectProvider({


### PR DESCRIPTION
This should remove the need for the vast majority of polyfills by explicitly using the UMD version of of WalletConnect & Torus. 

It's been tested on most examples after removing polyfills and is working successfully.