### PR TITLE
fix: outlet origin check for onchain tokens

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -940,7 +940,7 @@ export class Client {
 	}
 
 	getOutletConfigForCurrentOrigin() {
-		let allIssuers = this.tokenStore.getCurrentIssuers();
+		let allIssuers = this.tokenStore.getCurrentIssuers(false);
 		let currentIssuers = [];
 
 		Object.keys(allIssuers).forEach((key) => {
@@ -967,7 +967,7 @@ export class Client {
 	}
 
 	onlySameOrigin() {
-		let allIssuers = this.tokenStore.getCurrentIssuers();
+		let allIssuers = this.tokenStore.getCurrentIssuers(false);
 		let onlySameOriginFlag = true;
 
 		Object.keys(allIssuers).forEach((key) => {


### PR DESCRIPTION
This fixes an issue caused by checking issuerConfig.tokenOrigin for on-chain tokens. It simple adds the filter parameter to include only off-chain tokens.