### PR TITLE
Fix: Token redirect load error handler

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -498,9 +498,9 @@ export class Client {
 
 		let action = this.getDataFromQuery('action')
 
-		if (action === "error"){
-			this.handleRedirectTokensError();
-			return;
+		if (action === 'error') {
+			this.handleRedirectTokensError()
+			return
 		}
 
 		if (action !== OutletAction.GET_ISSUER_TOKENS + '-response') return
@@ -551,16 +551,16 @@ export class Client {
 		this.tokenStore.setTokens(issuer, tokens)
 	}
 
-	private async handleRedirectTokensError(){
-		const error = this.getDataFromQuery('error');
+	private async handleRedirectTokensError() {
+		const error = this.getDataFromQuery('error')
 
-		if (this.config.type === "active") {
-			this.createUiInstance();
-			await this.ui.initialize();
-			this.ui.showError(error);
+		if (this.config.type === 'active') {
+			this.createUiInstance()
+			await this.ui.initialize()
+			this.ui.showError(error)
 		}
 
-		console.log("Error loading tokens from outlet: ", error);
+		console.log('Error loading tokens from outlet: ', error)
 	}
 
 	async setPassiveNegotiationOnChainTokens() {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -498,6 +498,11 @@ export class Client {
 
 		let action = this.getDataFromQuery('action')
 
+		if (action === "error"){
+			this.handleRedirectTokensError();
+			return;
+		}
+
 		if (action !== OutletAction.GET_ISSUER_TOKENS + '-response') return
 
 		let issuer = this.getDataFromQuery('issuer')
@@ -544,6 +549,18 @@ export class Client {
 		logger(2, tokens)
 
 		this.tokenStore.setTokens(issuer, tokens)
+	}
+
+	private async handleRedirectTokensError(){
+		const error = this.getDataFromQuery('error');
+
+		if (this.config.type === "active") {
+			this.createUiInstance();
+			await this.ui.initialize();
+			this.ui.showError(error);
+		}
+
+		console.log("Error loading tokens from outlet: ", error);
 	}
 
 	async setPassiveNegotiationOnChainTokens() {

--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -273,8 +273,7 @@ export class Ui implements UiInterface {
 			}
 			error = error.message ? error.message : error.toString()
 		} else {
-			if (error === ClientError.USER_ABORT)
-				return this.dismissLoader();
+			if (error === ClientError.USER_ABORT) return this.dismissLoader()
 		}
 
 		this.loadContainer.querySelector('.loader-tn').style.display = 'none'

--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -272,6 +272,9 @@ export class Ui implements UiInterface {
 				return this.dismissLoader()
 			}
 			error = error.message ? error.message : error.toString()
+		} else {
+			if (error === ClientError.USER_ABORT)
+				return this.dismissLoader();
 		}
 
 		this.loadContainer.querySelector('.loader-tn').style.display = 'none'
@@ -326,11 +329,10 @@ export class Ui implements UiInterface {
 	}
 
 	protected setTheme(theme: UItheme) {
-		let refTokenSelector = document.querySelector('.overlay-tn')
-		if (refTokenSelector) {
-			refTokenSelector.classList.remove(this.options.theme + '-tn')
+		if (this.popupContainer) {
+			this.popupContainer.classList.remove(this.options.theme + '-tn')
 			theme = this.validateTheme(theme)
-			refTokenSelector.classList.add(theme + '-tn')
+			this.popupContainer.classList.add(theme + '-tn')
 			this.options.theme = theme
 		}
 	}

--- a/src/client/views/select-issuers.ts
+++ b/src/client/views/select-issuers.ts
@@ -85,8 +85,8 @@ export class SelectIssuers extends AbstractView {
 			this.autoLoadTokens(true)
 		})
 
-		this.issuerListContainer = document.querySelector('.token-issuer-list-container-tn')
-		this.tokensContainer = document.getElementsByClassName('token-view-tn')[0]
+		this.issuerListContainer = this.viewContainer.querySelector('.token-issuer-list-container-tn')
+		this.tokensContainer = this.viewContainer.getElementsByClassName('token-view-tn')[0]
 
 		if (!this.issuerListContainer) {
 			logger(2, 'Element .token-issuer-list-container-tn not found')
@@ -300,7 +300,7 @@ export class SelectIssuers extends AbstractView {
 		const config = tokenStore.getCurrentIssuers()[issuer]
 		const tokenData = tokenStore.getIssuerTokens(issuer) ?? []
 
-		if (config.title) document.getElementsByClassName('headline-tn token-name')[0].innerHTML = config.title
+		if (config.title) this.viewContainer.getElementsByClassName('headline-tn token-name')[0].innerHTML = config.title
 
 		let tokens: TokenListItemInterface[] = []
 

--- a/src/client/views/token-list.ts
+++ b/src/client/views/token-list.ts
@@ -46,7 +46,7 @@ export class TokenList extends AbstractView {
 								this.loadMoreTokens()
 							}
 						},
-						{ root: document.querySelector('.view-content-tn') },
+						{ root: this.viewContainer.querySelector('.view-content-tn') },
 					)
 
 				this.interceptObs.observe(loadMoreElem)

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -532,6 +532,7 @@ export class Outlet {
 			target.postMessage(response, '*')
 		}
 
+		// TODO: this is probably no longer needed as brave is set to always use redirect mode now
 		if (!this.isSameOrigin()) {
 			// At least Brave iOS browser blocks close(), so user have to see the message and close tab.
 			// Message appears when tokens succesully sent with postMessage

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -207,8 +207,8 @@ export class Outlet {
 				}
 			}
 		} catch (e: any) {
-			console.error(e)
-			this.sendErrorResponse(evtid, e.message)
+			console.error(e);
+			this.sendErrorResponse(evtid, e?.message ?? e);
 		}
 	}
 
@@ -461,6 +461,25 @@ export class Outlet {
 	}
 
 	public sendErrorResponse(evtid: any, error: string) {
+
+		let requestor = this.getDataFromQuery('requestor');
+
+		if (requestor){
+
+			let url = new URL(requestor)
+
+			const params = new URLSearchParams(url.hash.substring(1))
+			params.set('action', ResponseActionBase.ERROR)
+			params.set('error', error);
+
+			console.log("Redirecting error: ", error);
+
+			url.hash = '#' + params.toString()
+
+			document.location.href = url.href
+			return;
+		}
+
 		this.sendMessageResponse({
 			evtid: evtid,
 			evt: ResponseActionBase.ERROR,

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -207,8 +207,8 @@ export class Outlet {
 				}
 			}
 		} catch (e: any) {
-			console.error(e);
-			this.sendErrorResponse(evtid, e?.message ?? e);
+			console.error(e)
+			this.sendErrorResponse(evtid, e?.message ?? e)
 		}
 	}
 
@@ -461,23 +461,21 @@ export class Outlet {
 	}
 
 	public sendErrorResponse(evtid: any, error: string) {
+		let requestor = this.getDataFromQuery('requestor')
 
-		let requestor = this.getDataFromQuery('requestor');
-
-		if (requestor){
-
+		if (requestor) {
 			let url = new URL(requestor)
 
 			const params = new URLSearchParams(url.hash.substring(1))
 			params.set('action', ResponseActionBase.ERROR)
-			params.set('error', error);
+			params.set('error', error)
 
-			console.log("Redirecting error: ", error);
+			console.log('Redirecting error: ', error)
 
 			url.hash = '#' + params.toString()
 
 			document.location.href = url.href
-			return;
+			return
 		}
 
 		this.sendMessageResponse({

--- a/src/utils/support/getBrowserData.ts
+++ b/src/utils/support/getBrowserData.ts
@@ -111,8 +111,7 @@ export function isSafari() {
 
 export function browserBlocksIframeStorage(): boolean {
 	let browserData = getBrowserData()
-	// TODO remove Chrome from list
-	return browserData.iOS || isSafari() || isBrave()
+	return browserData.iOS || isSafari() || isBrave() || browserData.fireFox
 }
 
 export function shouldUseRedirectMode(redirectConfig?: 'always' | 'never') {


### PR DESCRIPTION
- Fix issues with multiple instances of token negotiator. Never use "document." within UI class, always use "viewContainer."
- Add missing error handling for off-chain token loading in redirect mode.