### PR TITLE
Fix: various 2.3 issues

### DIFF
--- a/src/client/auth/ticketZKProof.ts
+++ b/src/client/auth/ticketZKProof.ts
@@ -70,13 +70,14 @@ export class TicketZKProof extends AbstractAuthentication implements Authenticat
 				redirectMode,
 			)
 
-			// Since sendMessage is an async function, we need to add a delay here to prevent an exception
-			// from being thrown as redirect code-path returns void. We presume the redirect will be completed after 20 seconds
-			if (redirectMode) {
+			// Since sendMessage can return void in case of redirect, we need a promise here to prevent an exception.
+			// We presume the redirect will be completed after 30 seconds. We could change the "authenticate" function
+			// public interface to return void, but this would change the API which is not desired for obvious reasons.
+			if (!res) {
 				return new Promise((resolve, reject) => {
 					setTimeout(() => {
 						reject(new Error('The outlet failed to load.'))
-					}, 20000)
+					}, 30000)
 				})
 			}
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -580,6 +580,11 @@ export class Client {
 			this.ui.showError(error)
 		}
 
+		this.eventSender('error', {
+			issuer: this.getDataFromQuery('issuer'),
+			error: new Error(error),
+		})
+
 		console.log('Error loading tokens from outlet: ', error)
 	}
 
@@ -932,7 +937,10 @@ export class Client {
 				redirectRequired ? document.location.href : false,
 			)
 
-			if (!res) return // Site is redirecting
+			if (!res)
+				return new Promise((_resolve) => {
+					return
+				}) // Site is redirecting
 
 			if (res.evt === OutletResponseAction.ISSUER_TOKENS) {
 				// Store tokens if origin exists in config - this is a workaround for devcon

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -431,6 +431,8 @@ export class Client {
 			try {
 				let tokens = await this.connectTokenIssuer(issuerKey)
 
+				if (!tokens) return // Site is redirecting
+
 				onComplete(issuerKey, tokens)
 			} catch (e) {
 				e.message = 'Failed to load ' + issuerKey + ': ' + e.message
@@ -458,7 +460,7 @@ export class Client {
 		this.cancelAutoload = true
 	}
 
-	async setPassiveNegotiationWebTokens() {
+	async setPassiveNegotiationWebTokens(): Promise<void> {
 		let issuers = this.tokenStore.getCurrentIssuers(false)
 
 		let action = this.getDataFromQuery('action')
@@ -495,6 +497,8 @@ export class Client {
 						if (tokens !== null) continue
 
 						tokens = await this.loadRemoteOutletTokens(issuerConfig)
+
+						if (!tokens) return // Site is redirecting
 					}
 				}
 			} catch (error) {
@@ -640,7 +644,7 @@ export class Client {
 			)
 	}
 
-	async connectTokenIssuer(issuer: string) {
+	async connectTokenIssuer(issuer: string): Promise<unknown[] | void> {
 		const config = this.tokenStore.getCurrentIssuers()[issuer]
 		if (!config) errorHandler('Undefined token issuer', 'error', null, null, true, true)
 
@@ -664,6 +668,8 @@ export class Client {
 				tokens = this.loadLocalOutletTokens(config)
 			} else {
 				tokens = await this.loadRemoteOutletTokens(config)
+
+				if (!tokens) return // Site is redirecting
 			}
 		}
 
@@ -678,8 +684,12 @@ export class Client {
 		return tokens
 	}
 
-	private async loadRemoteOutletTokens(issuer: OffChainTokenConfig) {
-		const data: any = {
+	private async loadRemoteOutletTokens(issuer: OffChainTokenConfig): Promise<unknown[] | void> {
+		const data: {
+			issuer: OffChainTokenConfig
+			filter?: {}
+			access?: string
+		} = {
 			issuer: issuer,
 			filter: issuer.filters,
 		}
@@ -702,6 +712,8 @@ export class Client {
 			this.config.type === 'active' ? this.ui : null,
 			redirectRequired ? document.location.href : false,
 		)
+
+		if (!res) return // Site is redirecting
 
 		return res.data?.tokens ?? []
 	}
@@ -768,6 +780,8 @@ export class Client {
 			logger(2, 'get proof at ', window.location.href)
 
 			res = await authenticator.getTokenProof(config, [authRequest.unsignedToken], authRequest)
+
+			if (!res) return // Site is redirecting
 
 			logger(2, 'proof received at ', window.location.href)
 
@@ -846,7 +860,7 @@ export class Client {
 		Promise.resolve(this.on(eventName, null, data))
 	}
 
-	getOutletConfigForCurrentOrigin() {
+	getOutletConfigForCurrentOrigin(origin: string = document.location.origin) {
 		let allIssuers = this.tokenStore.getCurrentIssuers(false)
 		let currentIssuers = []
 
@@ -855,7 +869,7 @@ export class Client {
 
 			try {
 				if (
-					new URL(issuerConfig.tokenOrigin).origin === document.location.origin
+					new URL(issuerConfig.tokenOrigin).origin === origin
 					// should not be 2 tokens with same origin
 					// && issuerConfig.collectionID == issuer
 				) {
@@ -904,20 +918,32 @@ export class Client {
 
 		const redirectRequired = shouldUseRedirectMode(this.config.offChainRedirectMode)
 
-		let res = await this.messaging.sendMessage(
-			{
-				action: OutletAction.MAGIC_URL,
-				origin: url.origin + url.pathname,
-				data: {
-					urlParams: params,
+		try {
+			let res = await this.messaging.sendMessage(
+				{
+					action: OutletAction.MAGIC_URL,
+					origin: url.origin + url.pathname,
+					data: {
+						urlParams: params,
+					},
 				},
-			},
-			this.config.messagingForceTab,
-			undefined,
-			redirectRequired ? document.location.href : false,
-		)
-		if (res.evt === OutletResponseAction.ISSUER_TOKENS) return res.data.tokens
-		errorHandler(res.errors.join('\n'), 'error', null, false, true)
+				this.config.messagingForceTab,
+				undefined,
+				redirectRequired ? document.location.href : false,
+			)
+
+			if (!res) return // Site is redirecting
+
+			if (res.evt === OutletResponseAction.ISSUER_TOKENS) {
+				// Store tokens if origin exists in config - this is a workaround for devcon
+				const issuerConfig = this.getOutletConfigForCurrentOrigin(url.origin)
+				if (issuerConfig) this.tokenStore.setTokens(issuerConfig.collectionID, res.data.tokens)
+
+				return res.data.tokens
+			}
+		} catch (e) {
+			errorHandler(e.message, 'error', null, false, true)
+		}
 	}
 
 	on(type: TokenNegotiatorEvents, callback?: any, data?: any) {

--- a/src/client/messaging.ts
+++ b/src/client/messaging.ts
@@ -23,7 +23,7 @@ export class Messaging {
 		forceTab = false,
 		ui?: UiInterface,
 		redirectUrl: false | string = false,
-	): Promise<ResponseInterfaceBase> {
+	): Promise<ResponseInterfaceBase | void> {
 		try {
 			return await this.core.sendMessage(request, forceTab, redirectUrl)
 		} catch (e) {
@@ -46,7 +46,7 @@ export class Messaging {
 	}
 
 	private handleUserClose(request: RequestInterfaceBase, ui: UiInterface, forceTab) {
-		return new Promise<ResponseInterfaceBase>((resolve, reject) => {
+		return new Promise<ResponseInterfaceBase | void>((resolve, reject) => {
 			ui.showError('Mmmmm looks like your popup blocker is getting in the way.')
 
 			ui.setErrorRetryCallback(() => {

--- a/src/client/views/select-issuers.ts
+++ b/src/client/views/select-issuers.ts
@@ -236,12 +236,14 @@ export class SelectIssuers extends AbstractView {
 
 		const issuer = data.issuer
 
-		let tokens: any[] = []
+		let tokens: unknown[] | void = []
 
 		this.ui.showLoader('<h4>Loading tokens...</h4>')
 
 		try {
 			tokens = await this.client.connectTokenIssuer(issuer)
+
+			if (!tokens) return // Site is redirecting
 		} catch (err) {
 			logger(2, err)
 			this.ui.showError(err)

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -43,7 +43,7 @@ export class Messaging {
 		request: RequestInterfaceBase,
 		forceTab = false,
 		redirectUrl: false | string = false,
-	): Promise<ResponseInterfaceBase> {
+	): Promise<ResponseInterfaceBase | void> {
 		logger(2, 'Send request: ')
 		logger(2, request)
 

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -214,7 +214,7 @@ export class Outlet {
 			}
 		} catch (e: any) {
 			console.error(e)
-			this.sendErrorResponse(evtid, e?.message ?? e)
+			this.sendErrorResponse(evtid, e?.message ?? e, this.getDataFromQuery('issuer'))
 		}
 	}
 
@@ -468,12 +468,13 @@ export class Outlet {
 		})
 	}
 
-	public sendErrorResponse(evtid: any, error: string) {
+	public sendErrorResponse(evtid: any, error: string, issuer?: string) {
 		if (this.redirectCallbackUrl) {
 			let url = this.redirectCallbackUrl
 
 			const params = new URLSearchParams(url.hash.substring(1))
 			params.set('action', ResponseActionBase.ERROR)
+			params.set('issuer', issuer)
 			params.set('error', error)
 
 			console.log('Redirecting error: ', error)

--- a/src/utils/support/getBrowserData.ts
+++ b/src/utils/support/getBrowserData.ts
@@ -123,6 +123,6 @@ export function shouldUseRedirectMode(redirectConfig?: 'always' | 'never') {
 		case 'never':
 			return false
 		default:
-			return isBrave() || (browserData.iOS && !isSafari())
+			return isBrave() || browserData.fireFox || (browserData.iOS && !isSafari())
 	}
 }

--- a/src/wallet/SafeConnectProvider.ts
+++ b/src/wallet/SafeConnectProvider.ts
@@ -1,4 +1,3 @@
-import { ResponseInterfaceBase } from '../core/messaging'
 import { Messaging } from '../client/messaging'
 import { KeyStore } from '@tokenscript/attestation/dist/safe-connect/KeyStore'
 import { AbstractAuthentication, AuthenticationResult } from '../client/auth/abstractAuthentication'
@@ -32,7 +31,7 @@ export class SafeConnectProvider {
 	}
 
 	public async initSafeConnect() {
-		let res: ResponseInterfaceBase = await this.messaging.sendMessage(
+		let res = await this.messaging.sendMessage(
 			{
 				action: SafeConnectAction.CONNECT,
 				origin: this.options.url,
@@ -42,6 +41,8 @@ export class SafeConnectProvider {
 			true,
 			this.ui,
 		)
+
+		if (!res) return // Site is redirecting
 
 		if (!this.options.initialProof) return res.data.address
 
@@ -107,7 +108,7 @@ export class SafeConnectProvider {
 	}
 
 	public async signUNChallenge(un: UNInterface) {
-		let res: ResponseInterfaceBase = await this.messaging.sendMessage(
+		let res = await this.messaging.sendMessage(
 			{
 				action: SafeConnectAction.CONNECT,
 				origin: this.options.url,
@@ -120,6 +121,8 @@ export class SafeConnectProvider {
 			true,
 			this.ui,
 		)
+
+		if (!res) return // Site is redirecting
 
 		return res.data.data.signature
 	}


### PR DESCRIPTION
Fixed:
- TKS-628 Redirect mode causes exception before page reload
- TKS-736 Fix tokens automatic load not triggering due to stale tokenStore
- TKS-737 Firefox permission dialog not clickable (Windows & Android). Firefox should use redirect mode
- Fix addTokenViaMagicLink returning void in redirect mode & improve outlet error handling (relates to TKS-628)