### PR TITLE
feat: Add wallet provider options for WC v2

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -253,7 +253,7 @@ export class Client {
 	public async getWalletProvider() {
 		if (!this.web3WalletProvider) {
 			const { Web3WalletProvider } = await import('./../wallet/Web3WalletProvider')
-			this.web3WalletProvider = new Web3WalletProvider(this, this.config.safeConnectOptions)
+			this.web3WalletProvider = new Web3WalletProvider(this, this.config.walletOptions, this.config.safeConnectOptions)
 		}
 
 		return this.web3WalletProvider

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -3,6 +3,7 @@ import { AuthenticationMethod } from './auth/abstractAuthentication'
 import { SafeConnectOptions } from '../wallet/SafeConnectProvider'
 import { BrowserDataInterface } from '../utils/support/isSupported'
 import { WalletConnection } from '../wallet/Web3WalletProvider'
+import { ConnectParams as WCv2ConnectParams } from '@walletconnect/universal-provider/dist/types/types/misc'
 
 export interface OffChainTokenConfig extends IssuerConfigInterface {
 	onChain: false
@@ -65,6 +66,14 @@ export interface NegotiationInterface {
 		}
 	}
 	noInternetErrorMessage?: string
+	walletOptions?: WalletOptionsInterface
+}
+
+export interface WalletOptionsInterface {
+	walletConnectV2?: {
+		chains?: string[]
+		rpcMap: { [chainId: string]: string }
+	}
 }
 
 export interface AuthenticateInterface {

--- a/src/wallet/WalletConnectProvider.ts
+++ b/src/wallet/WalletConnectProvider.ts
@@ -1,24 +1,10 @@
 import WalletConnectProvider from '@walletconnect/web3-provider/dist/umd/index.min'
+import { WC_DEFAULT_RPC_MAP } from './WalletConnectV2Provider'
 
 export const getWalletConnectProviderInstance = async (checkConnectionOnly?: boolean) => {
 	return new WalletConnectProvider({
 		infuraId: '7753fa7b79d2469f97c156780fce37ac',
 		qrcode: !checkConnectionOnly,
-		rpc: {
-			5: 'https://eth-goerli.g.alchemy.com/v2/yVhq9zPJorAWsw-F87fEabSUl7cCU6z4', // Goerli
-			11155111: 'https://sepolia.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef', // Sepolia
-			137: 'https://polygon-rpc.com/', // Polygon
-			80001: 'https://polygon-mumbai.g.alchemy.com/v2/rVI6pOV4irVsrw20cJxc1fxK_1cSeiY0', // mumbai
-			56: 'https://bsc-dataseed.binance.org/', // BSC,
-			97: 'https://data-seed-prebsc-1-s1.binance.org:8545', // BSC testnet
-			43114: 'https://api.avax.network/ext/bc/C/rpc', // Avalanche
-			43113: 'https://api.avax-test.network/ext/bc/C/rpc', // Fuji testnet
-			250: 'https://rpc.fantom.network/', // Fantom,
-			25: 'https://evm-cronos.crypto.org', // Cronos,
-			338: 'https://evm-t3.cronos.org', // Cronos testnet(Rinkeby)
-			42161: 'https://arb1.arbitrum.io/rpc', // Arbitrum
-			421613: 'https://arb-goerli.g.alchemy.com/v2/nFrflomLgsQQL5NWjGileAVqIGGxZWce', // Arbitrum goerli,
-			10: 'https://mainnet.optimism.io',
-		},
+		rpc: WC_DEFAULT_RPC_MAP,
 	})
 }

--- a/src/wallet/WalletConnectV2Provider.ts
+++ b/src/wallet/WalletConnectV2Provider.ts
@@ -1,25 +1,24 @@
 import UniversalProvider from '@walletconnect/universal-provider/dist/index.umd'
 
-export const CUSTOM_RPCS_FOR_WC_V2 = {
+export const WC_DEFAULT_RPC_MAP = {
 	1: 'https://ethereum.publicnode.com', // mainnet
 	5: 'https://eth-goerli.g.alchemy.com/v2/yVhq9zPJorAWsw-F87fEabSUl7cCU6z4', // Goerli
-	// 11155111: 'https://sepolia.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef', // Sepolia
+	11155111: 'https://sepolia.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef', // Sepolia
 	137: 'https://polygon-rpc.com/', // Polygon
 	80001: 'https://polygon-mumbai.g.alchemy.com/v2/rVI6pOV4irVsrw20cJxc1fxK_1cSeiY0', // mumbai
 	56: 'https://bsc-dataseed.binance.org/', // BSC,
-	// 97: 'https://data-seed-prebsc-1-s1.binance.org:8545', // BSC testnet
+	97: 'https://data-seed-prebsc-1-s1.binance.org:8545', // BSC testnet
 	43114: 'https://api.avax.network/ext/bc/C/rpc', // Avalanche
-	// 43113: 'https://api.avax-test.network/ext/bc/C/rpc', // Fuji testnet
+	43113: 'https://api.avax-test.network/ext/bc/C/rpc', // Fuji testnet
 	250: 'https://rpc.fantom.network/', // Fantom,
 	25: 'https://evm-cronos.crypto.org', // Cronos,
-	// 338: 'https://evm-t3.cronos.org', // Cronos testnet(Rinkeby)
+	338: 'https://evm-t3.cronos.org', // Cronos testnet
 	42161: 'https://arb1.arbitrum.io/rpc', // Arbitrum
-	// 421613: 'https://arb-goerli.g.alchemy.com/v2/nFrflomLgsQQL5NWjGileAVqIGGxZWce', // Arbitrum goerli,
+	421613: 'https://arb-goerli.g.alchemy.com/v2/nFrflomLgsQQL5NWjGileAVqIGGxZWce', // Arbitrum goerli,
 	10: 'https://mainnet.optimism.io', // Optimism
 }
 
-// https://ethereum.publicnode.com
-export const WC_V2_CHAINS = [
+export const WC_V2_DEFAULT_CHAINS = [
 	'eip155:1', // Mainnet
 	// 'eip155:5',
 	// 'eip155:11155111',

--- a/src/wallet/Web3WalletProvider.ts
+++ b/src/wallet/Web3WalletProvider.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { logger } from '../utils'
 import { SafeConnectOptions } from './SafeConnectProvider'
 import { Client } from '../client'
+import { WalletOptionsInterface } from '../client/interface'
 
 interface WalletConnectionState {
 	[index: string]: WalletConnection
@@ -21,13 +22,11 @@ export class Web3WalletProvider {
 
 	connections: WalletConnectionState = {}
 
-	safeConnectOptions?: SafeConnectOptions
-	client: Client
-
-	constructor(client: Client, safeConnectOptions?: SafeConnectOptions) {
-		this.client = client
-		this.safeConnectOptions = safeConnectOptions
-	}
+	constructor(
+		private client: Client,
+		private walletOptions?: WalletOptionsInterface,
+		public safeConnectOptions?: SafeConnectOptions,
+	) {}
 
 	saveConnections() {
 		let savedConnections: WalletConnectionState = {}
@@ -40,7 +39,6 @@ export class Web3WalletProvider {
 				chainId: con.chainId,
 				providerType: con.providerType,
 				blockchain: con.blockchain,
-				ethers: ethers,
 			}
 		}
 
@@ -273,12 +271,9 @@ export class Web3WalletProvider {
 				namespaces: {
 					eip155: {
 						methods: ['eth_sendTransaction', 'eth_signTransaction', 'eth_sign', 'personal_sign', 'eth_signTypedData'],
-						chains: walletConnectProvider.WC_V2_CHAINS,
+						chains: this.walletOptions?.walletConnectV2?.chains ?? walletConnectProvider.WC_V2_DEFAULT_CHAINS,
 						events: ['chainChanged', 'accountsChanged'],
-						rpcMap: walletConnectProvider.CUSTOM_RPCS_FOR_WC_V2,
-						// rpcMap: {
-						// 	1: `https://mainnet.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef`
-						// }
+						rpcMap: this.walletOptions?.walletConnectV2?.rpcMap ?? walletConnectProvider.WC_DEFAULT_RPC_MAP,
 					},
 				},
 				pairingTopic: pairing?.topic,

--- a/src/wallet/__test__/wallet.spec.ts
+++ b/src/wallet/__test__/wallet.spec.ts
@@ -29,17 +29,12 @@ let tokenNegotiatorClient = new Client({
 	],
 })
 
-let safeConnectOptions: SafeConnectOptions = {
-	url: 'https://safeconnect.tokenscript.org',
-	initialProof: 'address_attest',
-}
-
 describe('wallet spec', () => {
 	let web3WalletProvider: Web3WalletProvider
 	let safeConnectProvider: SafeConnectProvider
 
 	test('web3WalletProvider a new instance', () => {
-		web3WalletProvider = new Web3WalletProvider(tokenNegotiatorClient, safeConnectOptions)
+		web3WalletProvider = new Web3WalletProvider(tokenNegotiatorClient, null, null)
 		expect(web3WalletProvider).toBeDefined()
 	})
 

--- a/src/wallet/__test__/wallet.spec.ts
+++ b/src/wallet/__test__/wallet.spec.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
+import { TextDecoder, TextEncoder } from 'text-encoding'
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder
 import { Client } from '../../client/index'
 import { SafeConnectOptions, SafeConnectProvider } from '../SafeConnectProvider'
 import { Web3WalletProvider } from '../Web3WalletProvider'


### PR DESCRIPTION
Expose WalletConnect v2 options required for specifying chains included in the connection request.

This is require for WCv2 to be compatible with our e-commerce example for minting. 