### PR TITLE
Fix: various issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/token-negotiator",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Token-negotiator a token attestation bridge between web 2.0 and 3.0.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -375,6 +375,7 @@ export class Client {
 
 		await this.checkUserAgentSupport('full')
 		if (issuers) {
+			this.config.issuers = issuers
 			this.tokenStore.updateIssuers(issuers)
 		}
 


### PR DESCRIPTION
- Ensure this.config.issuers is kept up to date with issuers specified via the negotiate function.
- Ensure view name is set correctly and view-changed event is only emitted after successful render.
- Add viewOptions.componentIsFactory. It's impossible to determine whether a variable is a 
  class constructor or a function reliably. And calling factory with new keyword breaks es6 builds.