### PR TITLE
Patch version 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenscript/token-negotiator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Token-negotiator a token attestation bridge between web 2.0 and 3.0.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // modified by build process.
-export const VERSION = '2.4.0'
+export const VERSION = '2.4.2'

--- a/src/wallet/WalletConnectV2Provider.ts
+++ b/src/wallet/WalletConnectV2Provider.ts
@@ -1,4 +1,4 @@
-import UniversalProvider from '@walletconnect/universal-provider/dist/index.es'
+import UniversalProvider from '@walletconnect/universal-provider'
 
 export const WC_DEFAULT_RPC_MAP = {
 	1: 'https://ethereum.publicnode.com', // mainnet


### PR DESCRIPTION
Now that TN targets ES6, specifying full module path (@walletconnect/universal-provider/dist/index.es) is unnecessary and causes an error in some projects.