### PR TITLE
feat: multi-blockchain & wallet support overhaul - core internal API changes

### DIFF
--- a/src/client/auth/attestedAddress.ts
+++ b/src/client/auth/attestedAddress.ts
@@ -19,7 +19,7 @@ export class AttestedAddress extends AbstractAuthentication implements Authentic
 
 		if (!request.options?.address) throw new Error('Address attestation requires a secondary address.')
 
-		let wallet = web3WalletProvider.getConnectedWalletData()[0]
+		let wallet = web3WalletProvider.getConnectedWalletData('evm')?.[0]
 
 		let currentProof: AuthenticationResult | null = this.getSavedProof(wallet.address)
 

--- a/src/client/auth/safeConnectChallenge.ts
+++ b/src/client/auth/safeConnectChallenge.ts
@@ -19,7 +19,7 @@ export class SafeConnectChallenge extends AbstractAuthentication implements Auth
 
 		if (!issuerConfig.onChain) throw new Error(this.TYPE + ' is not available for off-chain tokens.')
 
-		let address = web3WalletProvider.getConnectedWalletData()[0].address
+		let address = web3WalletProvider.getConnectedWalletAddresses('evm')?.[0]
 
 		let currentProof: AuthenticationResult | null = this.getSavedProof(address)
 
@@ -31,7 +31,7 @@ export class SafeConnectChallenge extends AbstractAuthentication implements Auth
 		let safeConnect = await web3WalletProvider.getSafeConnectProvider()
 
 		if (!currentProof) {
-			let walletConnection = web3WalletProvider.getConnectedWalletData()[0].provider
+			let walletConnection = web3WalletProvider.getConnectedWalletData('evm')?.[0].provider
 
 			if (walletConnection instanceof SafeConnectProvider) {
 				// This will request and save a new challenge from safe connect

--- a/src/client/auth/signedUNChallenge.ts
+++ b/src/client/auth/signedUNChallenge.ts
@@ -14,11 +14,12 @@ export class SignedUNChallenge extends AbstractAuthentication implements Authent
 	): Promise<AuthenticationResult> {
 		let web3WalletProvider = await this.client.getWalletProvider()
 
-		if (web3WalletProvider.getConnectedWalletData().length === 0) {
+		// TODO: Update once Flow & Solana signing support is added
+		if (web3WalletProvider.getConnectedWalletData('evm').length === 0) {
 			throw new Error('WALLET_REQUIRED')
 		}
 
-		let address = web3WalletProvider.getConnectedWalletData()[0].address
+		let address = web3WalletProvider.getConnectedWalletAddresses('evm')[0]
 
 		let currentProof: AuthenticationResult | null = this.getSavedProof(address)
 

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -3,7 +3,8 @@ import { AuthenticationMethod } from './auth/abstractAuthentication'
 import { SafeConnectOptions } from '../wallet/SafeConnectProvider'
 import { BrowserDataInterface } from '../utils/support/isSupported'
 import { WalletConnection } from '../wallet/Web3WalletProvider'
-import { ConnectParams as WCv2ConnectParams } from '@walletconnect/universal-provider/dist/types/types/misc'
+
+export type SupportedBlockchainsParam = 'evm' | 'flow' | 'solana'
 
 export interface OffChainTokenConfig extends IssuerConfigInterface {
 	onChain: false
@@ -19,7 +20,7 @@ export interface OnChainTokenConfig extends IssuerConfigInterface {
 	contract: string
 	chain: string
 	openSeaSlug?: string
-	blockchain?: string
+	blockchain?: SupportedBlockchainsParam
 }
 
 export interface SolanaIssuerConfig extends OnChainTokenConfig {
@@ -78,7 +79,7 @@ export interface WalletOptionsInterface {
 }
 
 export interface AuthenticateInterface {
-	issuer: any
+	issuer: string
 	tokenId?: number | string
 	unsignedToken: any
 	address?: string

--- a/src/client/ui.ts
+++ b/src/client/ui.ts
@@ -160,7 +160,7 @@ export class Ui implements UiInterface {
 		if (this.client.getTokenStore().hasOnChainTokens()) {
 			let wp = await this.client.getWalletProvider()
 			await wp.loadConnections()
-			return wp.getConnectedWalletData().length > 0
+			return wp.hasAnyConnection(this.client.getTokenStore().getCurrentBlockchains())
 		} else {
 			return true
 		}

--- a/src/client/views/manage-wallets.ts
+++ b/src/client/views/manage-wallets.ts
@@ -1,0 +1,9 @@
+import { AbstractView } from './view-interface'
+
+class ManageWallets extends AbstractView {
+	render() {
+		this.viewContainer.innerHTML = `
+			<h1>Wallet Connections Here!</h1>
+		`
+	}
+}

--- a/src/wallet/__test__/wallet.spec.ts
+++ b/src/wallet/__test__/wallet.spec.ts
@@ -70,6 +70,7 @@ describe('wallet spec', () => {
 			'1',
 			'MetaMask',
 			walletConnect,
+			'evm',
 		)
 		web3WalletProvider.emitSavedConnection('0x1263b90F4e1DFe89A8f9E623FF57adb252851fC3')
 	})
@@ -82,6 +83,7 @@ describe('wallet spec', () => {
 			'1',
 			'MetaMask',
 			walletConnect,
+			'evm',
 		)
 		expect(web3WalletProvider.emitNetworkChange('0x2')).toBe('0x2')
 	})
@@ -89,11 +91,13 @@ describe('wallet spec', () => {
 	test('web3WalletProvider method registerNewWalletAddress and getConnectedWalletData', async () => {
 		const walletConnectProvider = await import('../WalletConnectProvider')
 		const walletConnect = await walletConnectProvider.getWalletConnectProviderInstance()
-		expect(web3WalletProvider.registerNewWalletAddress('0x123', '1', 'MetaMask', walletConnect)).toEqual('0x123')
+		expect(web3WalletProvider.registerNewWalletAddress('0x123', '1', 'MetaMask', walletConnect, 'evm')).toEqual('0x123')
 		const TorusProvider = await import('../TorusProvider')
 		const torus = await TorusProvider.getTorusProviderInstance()
-		expect(web3WalletProvider.registerNewWalletAddress('0x12345', '1', 'phantom', torus.provider)).toEqual('0x12345')
-		expect(web3WalletProvider.getConnectedWalletData()).toBeDefined()
+		expect(web3WalletProvider.registerNewWalletAddress('0x12345', '1', 'phantom', torus.provider, 'solana')).toEqual(
+			'0x12345',
+		)
+		expect(web3WalletProvider.getConnectedWalletData('evm')).toBeDefined()
 	})
 
 	test('web3WalletProvider method connectWith - MetaMask', async () => {


### PR DESCRIPTION
This PR introduces core changes required in order to support multi-wallet & multi-blockchain functionality. 
It does not introduce any new features and has backward compatibility for the current UX. 

- Add blockchain param to getConnectedWalletData method & update usages.
- Add new wallet helper methods hasAnyConnection & getConnectedWalletAddresses.
- Use hasAnyConnection to determine if initial wallet screen is skippable.
- Add interfaces for token data in TokenStore.
- Add getCurrentBlockchains method to TokenStore to determine blockchains for current issuers.
- Fix erc-20 for passive negotiation, refactor token loading into separate loadOnChainTokens() method for both active/passive loading use.
- Store wallet address in token data for later use.
- Update TokenStore.clearCachedTokens to support clearing tokens for a specific wallet.