### PR TITLE
Fix: prettier eslint format conflict

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended"
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
     ],
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,6 @@
             "undefined"
         ],
         "id-match": "error",
-        "indent": ["error", "tab", { "SwitchCase": 1 }],
         "no-eval": "error",
         "no-redeclare": "error",
         "no-trailing-spaces": "off",

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,7 +9,7 @@ module.exports = {
         "useTabs": true,
         "singleQuote": true,
         "trailingComma": "all",
-        "printWidth": 120,
+        "printWidth": 140,
         "semi": false
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenscript/token-negotiator",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenscript/token-negotiator",
-      "version": "2.4.0",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@datadog/browser-rum": "^4.35.0",
@@ -39,6 +39,7 @@
         "crypto-browserify": "^3.12.0",
         "css-loader": "^6.5.1",
         "eslint": "^8.18.0",
+        "eslint-config-prettier": "^8.8.0",
         "file-loader": "^6.2.0",
         "https-browserify": "^1.0.0",
         "husky": "^8.0.0",
@@ -7600,6 +7601,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -22840,6 +22853,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "crypto-browserify": "^3.12.0",
     "css-loader": "^6.5.1",
     "eslint": "^8.18.0",
+    "eslint-config-prettier": "^8.8.0",
     "file-loader": "^6.2.0",
     "https-browserify": "^1.0.0",
     "husky": "^8.0.0",


### PR DESCRIPTION
Hey @nicktaras this should fix most of the formatting conflicts between eslint & prettier.
And increases printWidth to be in line with CSS setting. This makes the HTML template literals a clearer to read but can be changed back if you want.