### PR TITLE
Chore: minimize bundle size

### DIFF
--- a/src/client/auth/ticketZKProof.ts
+++ b/src/client/auth/ticketZKProof.ts
@@ -1,10 +1,8 @@
 import { AbstractAuthentication, AuthenticationMethod, AuthenticationResult } from './abstractAuthentication'
 import { AuthenticateInterface, OffChainTokenConfig, OnChainTokenConfig } from '../interface'
 import { OutletAction, Messaging } from '../messaging'
-import { Authenticator } from '@tokenscript/attestation'
 import { SignedUNChallenge } from './signedUNChallenge'
 import { UNInterface } from './util/UN'
-import { LocalOutlet } from '../../outlet/localOutlet'
 import { OutletInterface } from '../../outlet'
 import { logger } from '../../utils'
 import { shouldUseRedirectMode } from '../../utils/support/getBrowserData'
@@ -47,7 +45,7 @@ export class TicketZKProof extends AbstractAuthentication implements Authenticat
 		let data
 
 		if (new URL(issuerConfig.tokenOrigin).origin === document.location.origin) {
-			const localOutlet = new LocalOutlet(issuerConfig as OffChainTokenConfig & OutletInterface)
+			const localOutlet = new (await import('../../outlet/localOutlet')).LocalOutlet(issuerConfig as OffChainTokenConfig & OutletInterface)
 
 			data = {}
 			data.proof = await localOutlet.authenticate(tokens[0], address, wallet, redirectMode)
@@ -92,6 +90,7 @@ export class TicketZKProof extends AbstractAuthentication implements Authenticat
 		}
 
 		if (useEthKey) {
+			const Authenticator = (await import('@tokenscript/attestation')).Authenticator
 			Authenticator.validateUseTicket(
 				data.proof,
 				issuerConfig.base64attestorPubKey,

--- a/src/outlet/__tests__/outlet.spec.ts
+++ b/src/outlet/__tests__/outlet.spec.ts
@@ -1,21 +1,30 @@
 import { Outlet } from '../index'
+import { LocalOutlet } from '../localOutlet'
 /*
   TODO: Find a solution for TypeError: Cannot convert a BigInt value to a number at Math.pow (<anonymous>)
   Thrown by import {Authenticator} from '@tokenscript/attestation' due to @tokenscript/attestation/src/libs/Point.ts
 */
 
-// @ts-ignore
-const outlet = new Outlet({
+const devconConfig = {
 	collectionID: 'devcon',
 	title: 'Devcon',
-	tokenOrigin: 'http://localhost:3002/',
+	tokenOrigin: document.location.origin,
 	attestationOrigin: 'https://test.attestation.id/',
 	base64senderPublicKeys: {
 		'6': 'MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBA0IABGMxHraqggr2keTXszIcchTjYjH5WXpDaBOYgXva82mKcGnKgGRORXSmcjWN2suUCMkLQj3UNlZCFWF10wIrrlw=',
 	},
 	base64attestorPubKey:
 		'MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBA0IABL+y43T1OJFScEep69/yTqpqnV/jzONz9Sp4TEHyAJ7IPN9+GHweCX1hT4OFxt152sBN3jJc1s0Ymzd8pNGZNoQ=',
-})
+}
+
+window.history.pushState(
+	null,
+	'',
+	'/?ticket=MIGTME0MATYCAgTTAgEBBEEELP0-vySEqJgldcvPSwL5VH_Bjta--7eHQafKwrwvH5MaPlOxSUqRtPf4GLs73BRJy-shtne8OV5C2e4-6qf5ggNCAEBVl-qTKHcKDKyjNszQ2NOOHS78dp56zQ6kWxxP2R4bE8-ZQs_zfTUS_HcNaLvyrsiil9ihndmcYD32Traiyscc&secret=45845870684&id=miccy@smarttokenlabs.com',
+)
+
+// @ts-ignore
+const outlet = new Outlet(devconConfig)
 
 describe('Test magic link token merging', () => {
 	// TicketId: 1235; Email 1
@@ -49,10 +58,70 @@ describe('Test magic link token merging', () => {
 	})
 	test('Expect existing attestation with same ID to be overwritten', () => {
 		const tokens = outlet.mergeNewToken(ticket2, [ticket1]) as any[]
-		expect(true).toBe(true)
+		expect(tokens.length).toBe(1)
 	})
 	test('Expect duplicate attestation to be skipped', () => {
 		const tokens = outlet.mergeNewToken(ticket1, [ticket1])
 		expect(tokens).toBe(false)
+	})
+})
+
+describe('Test local outlet', () => {
+	window.history.pushState(
+		null,
+		'',
+		'/?ticket=MIGTME0MATYCAgTTAgEBBEEELP0-vySEqJgldcvPSwL5VH_Bjta--7eHQafKwrwvH5MaPlOxSUqRtPf4GLs73BRJy-shtne8OV5C2e4-6qf5ggNCAEBVl-qTKHcKDKyjNszQ2NOOHS78dp56zQ6kWxxP2R4bE8-ZQs_zfTUS_HcNaLvyrsiil9ihndmcYD32Traiyscc&secret=45845870684&id=miccy@smarttokenlabs.com',
+	)
+
+	// @ts-ignore
+	const localOutlet = new LocalOutlet(devconConfig)
+
+	test('Read magic link', () => {
+		expect(() => localOutlet.readMagicLink()).not.toThrow()
+	})
+
+	test('check token was installed', () => {
+		const tokens = localOutlet.getTokens()
+		expect(tokens.length).toBe(1)
+	})
+
+	test('Authenticate iframe', () => {
+		const tokens = localOutlet.getTokens()
+
+		localOutlet.authenticate(tokens[0], '0x00', 'MetaMask')
+	})
+
+	/* test("Authenticate redirect", () => {
+		const tokens = localOutlet.getTokens();
+
+		localOutlet.authenticate(tokens[0], "0x00", "MetaMask", document.location.href)
+	})*/
+})
+
+describe('Test remote outlet', () => {
+	window.history.pushState(
+		null,
+		'',
+		'/?ticket=MIGTME0MATYCAgTTAgEBBEEELP0-vySEqJgldcvPSwL5VH_Bjta--7eHQafKwrwvH5MaPlOxSUqRtPf4GLs73BRJy-shtne8OV5C2e4-6qf5ggNCAEBVl-qTKHcKDKyjNszQ2NOOHS78dp56zQ6kWxxP2R4bE8-ZQs_zfTUS_HcNaLvyrsiil9ihndmcYD32Traiyscc&secret=45845870684&id=miccy@smarttokenlabs.com',
+	)
+
+	// @ts-ignore
+	const outlet = new Outlet(devconConfig)
+
+	test('Read magic link', () => {
+		expect(() => outlet.readMagicLink()).not.toThrow()
+	})
+
+	test('check token was installed', () => {
+		const tokens = outlet.prepareTokenOutput({})
+		expect(tokens.length).toBe(1)
+	})
+
+	test('test is same origin', () => {
+		expect(outlet.isSameOrigin()).toBe(true)
+	})
+
+	test('send error response', () => {
+		expect(() => outlet.sendErrorResponse('123', 'Test error')).not.toThrow()
 	})
 })

--- a/src/outlet/abstractOutlet.ts
+++ b/src/outlet/abstractOutlet.ts
@@ -1,0 +1,164 @@
+import { defaultConfig, OutletInterface, readSignedTicket } from './index'
+import { OffChainTokenConfig } from '../client/interface'
+import { DecodedToken, decodeToken, OffChainTokenData, rawTokenCheck, readTokenFromMagicUrl, readTokens, storeMagicURL } from '../core'
+import { Authenticator } from '@tokenscript/attestation'
+import { logger } from '../utils'
+import { URLNS } from '../core/messaging'
+
+export abstract class AbstractOutlet {
+	protected tokenConfig
+	protected urlParams
+
+	constructor(config: OutletInterface | (OutletInterface & OffChainTokenConfig), urlParams: URLSearchParams = null) {
+		this.tokenConfig = Object.assign(defaultConfig, config)
+
+		// set default tokenReader
+		if (!this.tokenConfig.tokenParser) {
+			this.tokenConfig.tokenParser = readSignedTicket
+		}
+
+		if (urlParams) {
+			this.urlParams = urlParams
+		} else {
+			let params = window.location.hash.length > 1 ? '?' + window.location.hash.substring(1) : window.location.search
+			this.urlParams = new URLSearchParams(params)
+		}
+	}
+
+	public async readMagicLink() {
+		const { tokenUrlName, tokenSecretName, tokenIdName, itemStorageKey } = this.tokenConfig
+
+		try {
+			const newToken = readTokenFromMagicUrl(tokenUrlName, tokenSecretName, tokenIdName, this.urlParams)
+			let tokensOutput = readTokens(itemStorageKey)
+
+			const newTokens = this.mergeNewToken(newToken, tokensOutput.tokens)
+
+			if (newTokens !== false) {
+				storeMagicURL(newTokens, itemStorageKey)
+			}
+
+			const event = new Event('tokensupdated')
+
+			// Dispatch the event to force negotiator to reread tokens.
+			// MagicLinkReader part of Outlet usually works in the parent window, same as Client, so it use same document
+			document.body.dispatchEvent(event)
+		} catch (e) {
+			console.warn(e)
+		}
+	}
+
+	/**
+	 * Merges a new magic link into the existing token data. If a token is found with the same ID it is overwritten.
+	 * @private
+	 * @returns false when no changes to the data are required - the token is already added
+	 */
+	protected mergeNewToken(newToken: OffChainTokenData, existingTokens: OffChainTokenData[]): OffChainTokenData[] | false {
+		const decodedNewToken = decodeToken(newToken, this.tokenConfig.tokenParser, this.tokenConfig.unsignedTokenDataName, false)
+
+		const newTokenId = this.getUniqueTokenId(decodedNewToken)
+
+		for (const [index, tokenData] of existingTokens.entries()) {
+			// Nothing required, this token already exists
+			if (tokenData.token === newToken.token) {
+				return false
+			}
+
+			const decodedTokenData = decodeToken(tokenData, this.tokenConfig.tokenParser, this.tokenConfig.unsignedTokenDataName, false)
+
+			const tokenId = this.getUniqueTokenId(decodedTokenData)
+
+			// Overwrite existing token
+			if (newTokenId === tokenId) {
+				existingTokens[index] = newToken
+				return existingTokens
+			}
+		}
+
+		// Add as new token
+		existingTokens.push(newToken)
+		return existingTokens
+	}
+
+	/**
+	 * Calculates a unique token ID to identify this ticket. Tickets can be reissued and have a different commitment, but are still the same token
+	 * @private
+	 */
+	private getUniqueTokenId(decodedToken: DecodedToken) {
+		return `${decodedToken.devconId}-${decodedToken.ticketIdNumber ?? decodedToken.ticketIdString}`
+	}
+
+	getDataFromQuery(itemKey: string, namespaced = true): string {
+		itemKey = (namespaced ? URLNS : '') + itemKey
+		return this.urlParams ? this.urlParams.get(itemKey) : ''
+	}
+
+	public async processAttestationIdCallback() {
+		const tokenString = this.getDataFromQuery('token')
+		let token = JSON.parse(tokenString)
+
+		// Note: these params come from attestation.id and are not namespaced
+		const attestationBlob = this.getDataFromQuery('attestation', false)
+		const attestationSecret = '0x' + this.getDataFromQuery('requestSecret', false)
+
+		const tokenObj = await rawTokenCheck(token, this.tokenConfig)
+
+		return await this.getUseToken(attestationBlob, attestationSecret, tokenObj)
+	}
+
+	public async getUseToken(attestationBlob: any, attestationSecret: any, tokenObj) {
+		try {
+			if (!tokenObj.signedTokenSecret) {
+				throw new Error('signedTokenSecret required')
+			}
+			if (!attestationSecret) {
+				throw new Error('attestationSecret required')
+			}
+			if (!tokenObj.signedTokenBlob) {
+				throw new Error('signedTokenBlob required')
+			}
+			if (!attestationBlob) {
+				throw new Error('attestationBlob required')
+			}
+			if (!this.tokenConfig.base64attestorPubKey) {
+				throw new Error('base64attestorPubKey required')
+			}
+			if (!this.tokenConfig.base64senderPublicKeys) {
+				throw new Error('base64senderPublicKeys required')
+			}
+
+			let useToken = await Authenticator.getUseTicket(
+				tokenObj.signedTokenSecret,
+				attestationSecret,
+				tokenObj.signedTokenBlob,
+				attestationBlob,
+				this.tokenConfig.base64attestorPubKey,
+				this.tokenConfig.base64senderPublicKeys,
+			)
+
+			if (useToken) {
+				logger(2, 'this.authResultCallback( useToken ): ')
+				return useToken
+			} else {
+				logger(2, 'this.authResultCallback( empty ): ')
+				throw new Error('Empty useToken')
+			}
+		} catch (e) {
+			logger(2, `UseDevconTicket failed.`, e.message)
+			logger(3, e)
+			throw new Error('Failed to create UseTicket. ' + e.message)
+		}
+	}
+
+	protected dispatchAuthCallbackEvent(issuer: string, proof?: string, error?: string) {
+		const event = new CustomEvent('auth-callback', {
+			detail: {
+				proof: proof,
+				issuer: issuer,
+				error: error,
+			},
+		})
+
+		window.dispatchEvent(event)
+	}
+}

--- a/src/outlet/abstractOutlet.ts
+++ b/src/outlet/abstractOutlet.ts
@@ -53,7 +53,7 @@ export abstract class AbstractOutlet {
 	 * @private
 	 * @returns false when no changes to the data are required - the token is already added
 	 */
-	protected mergeNewToken(newToken: OffChainTokenData, existingTokens: OffChainTokenData[]): OffChainTokenData[] | false {
+	public mergeNewToken(newToken: OffChainTokenData, existingTokens: OffChainTokenData[]): OffChainTokenData[] | false {
 		const decodedNewToken = decodeToken(newToken, this.tokenConfig.tokenParser, this.tokenConfig.unsignedTokenDataName, false)
 
 		const newTokenId = this.getUniqueTokenId(decodedNewToken)

--- a/src/outlet/auth-handler.ts
+++ b/src/outlet/auth-handler.ts
@@ -307,52 +307,6 @@ export class AuthHandler {
 		document.body.appendChild(iframeWrap)
 	}
 
-	public async getUseToken(attestationBlob: any, attestationSecret: any) {
-		try {
-			if (!this.signedTokenSecret) {
-				throw new Error('signedTokenSecret required')
-			}
-			if (!attestationSecret) {
-				throw new Error('attestationSecret required')
-			}
-			if (!this.signedTokenBlob) {
-				throw new Error('signedTokenBlob required')
-			}
-			if (!attestationBlob) {
-				throw new Error('attestationBlob required')
-			}
-			if (!this.base64attestorPubKey) {
-				throw new Error('base64attestorPubKey required')
-			}
-			if (!this.base64senderPublicKeys) {
-				throw new Error('base64senderPublicKeys required')
-			}
-
-			let useToken = await Authenticator.getUseTicket(
-				this.signedTokenSecret,
-				attestationSecret,
-				this.signedTokenBlob,
-				attestationBlob,
-				this.base64attestorPubKey,
-				this.base64senderPublicKeys,
-			)
-
-			if (useToken) {
-				logger(2, 'this.authResultCallback( useToken ): ')
-				if (this.buttonOverlay) this.buttonOverlay.remove()
-				return useToken
-			} else {
-				logger(2, 'this.authResultCallback( empty ): ')
-				throw new Error('Empty useToken')
-			}
-		} catch (e) {
-			logger(2, `UseDevconTicket failed.`, e.message)
-			logger(3, e)
-			if (this.buttonOverlay) this.buttonOverlay.remove()
-			throw new Error('Failed to create UseTicket. ' + e.message)
-		}
-	}
-
 	async postMessageAttestationListener(event: MessageEvent, resolve: Function, reject: Function) {
 		logger(2, 'postMessageAttestationListener event (auth-handler)', event.data)
 

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -375,7 +375,7 @@ export class Outlet extends AbstractOutlet {
 		document.location.href = requesterURL + '#' + params.toString()
 	}
 
-	private isSameOrigin() {
+	public isSameOrigin() {
 		try {
 			let tokenUrl = new URL(this.tokenConfig.tokenOrigin)
 			if (tokenUrl.origin === document.location.origin) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,11 @@ const TerserPlugin = require('terser-webpack-plugin')
 module.exports = {
     mode: "production",
     target: 'web',
-    entry: './src/index.ts',
+	//entry: './src/index.ts',
+    entry: {
+		Client: './src/client/index.ts',
+		Outlet: './src/outlet/index.ts'
+	},
     plugins: [
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
@@ -73,8 +77,8 @@ module.exports = {
     },
     output: {
         library: 'negotiator',
-        filename: 'negotiator.js',
-		chunkFilename: 'negotiator-[chunkhash].js',
+        filename: 'negotiator-[name].js',
+		chunkFilename: 'negotiator-[name]-[chunkhash].js',
         libraryTarget: 'umd',
         path: path.resolve(__dirname, 'token-negotiator-dist'),
     },


### PR DESCRIPTION
Optimizations to reduce UMD bundle entrypoint file. The extra dynamic imports should also optimize usages of the NPM package depending on bundler & configuration used (i.e. bundler setup to support chunking & tree shaking). 

- Always use LocalOutlet in client rather than normal Outlet.
- Create AbstractOutlet to share methods required by both LocalOutlet & Outlet.
- Dynamically load several classes when required:
  - LocalOutlet
  - Web3WalletProvider (this was already being dynamically import but also statically imported for type usage. I've updated this to import type only)
  - Authentication methods ticketZKProof & signedUNChallenge
  - Authenticator library
- Cleanup and remove some redundant functionality in Outlet.
- Separate webpack entrypoint files for Client & Outlet.