### PR TITLE
removed unsupported chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ The following types of tokens are supported:
     </tr>
     <tr>
 	    <td>evm</td>
-      <td>avalanche testnet</td>
-      <td>Y</td>
-    </tr>
-    <tr>
-	    <td>evm</td>
       <td>fantom</td>
       <td>N</td>
     </tr>
@@ -83,11 +78,6 @@ The following types of tokens are supported:
       <td>evm</td>
       <td>cronos</td>
       <td>N</td>
-    </tr>
-    <tr>
-      <td>evm</td>
-      <td>cronos testnet</td>
-      <td>Y</td>
     </tr>
     <tr>
 	  <td>solana</td>


### PR DESCRIPTION
Minor change added to remove the notice of support for Cronos and Avalanche Test Net (Expires 15th May 2023)

<img width="258" alt="Screen Shot 2023-05-15 at 11 23 44 am" src="https://github.com/TokenScript/token-negotiator/assets/6808817/c2138f78-6037-46ca-9c8d-eb4cdabe28c6">
