### PR TITLE
Feat: always include signed token

### DIFF
--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -314,16 +314,6 @@ export class Outlet {
 		return 'user-accept'
 	}
 
-	async prepareTokenOutput(filter?: FilterInterface) {
-		let includeSigned = false
-
-		if (this.tokenConfig.signedTokenWhitelist?.length && this.tokenConfig.signedTokenWhitelist.indexOf(this.getRequestOrigin()) > -1) {
-			includeSigned = true
-		}
-
-		return this.ticketStorage.getDecodedTokens(includeSigned, filter)
-	}
-
 	async sendTokenProof(evtid: any, token: any, address: string, wallet: string) {
 		if (!token) return 'error'
 
@@ -355,21 +345,9 @@ export class Outlet {
 		}
 	}
 
-	private getRequestOrigin() {
-		const requester = document.referrer
-
-		if (!requester) return null
-
-		try {
-			return new URL(requester).origin
-		} catch (e) {
-			return null
-		}
-	}
-
 	// TODO: Consolidate redirect callback for tokens, proof & errors into the sendMessageResponse function to remove duplication
 	private async sendTokens(evtid: any) {
-		let issuerTokens = await this.prepareTokenOutput(this.getFilter())
+		let issuerTokens = await this.ticketStorage.getDecodedTokens(this.getFilter())
 
 		logger(2, 'issuerTokens: (Outlet.sendTokens)', issuerTokens)
 

--- a/src/outlet/localOutlet.ts
+++ b/src/outlet/localOutlet.ts
@@ -18,7 +18,7 @@ export class LocalOutlet {
 	}
 
 	async getTokens() {
-		return this.ticketStorage.getDecodedTokens(true, this.tokenConfig.filter)
+		return this.ticketStorage.getDecodedTokens(this.tokenConfig.filter)
 	}
 
 	async authenticate(decodedToken: DecodedToken, address: string, wallet: string, redirectMode: false | string = false) {

--- a/src/outlet/ticketStorage.ts
+++ b/src/outlet/ticketStorage.ts
@@ -85,14 +85,11 @@ export class TicketStorage {
 		})
 	}
 
-	public async getDecodedTokens(includeSignedToken = false, filter?: FilterInterface) {
+	public async getDecodedTokens(filter?: FilterInterface) {
 		const tokens = await Promise.all(
 			this.tickets.map(async (ticket) => {
 				const tokenData = await this.decodeTokenData(ticket.type, ticket.token)
-
-				tokenData.type = ticket.type
-
-				return includeSignedToken ? { signedToken: ticket.token, ...tokenData } : tokenData
+				return { type: ticket.type, signedToken: ticket.token, ...tokenData }
 			}),
 		)
 


### PR DESCRIPTION
Rather than restricting signedToken to domains that are whitelisted by the issuer, this allows domains whitelisted by the user to gain access to the signedToken too. 

- signedTokenWhitelist remains but just grants access for the domain to get the token without user permission prompt
- token is returned to all domains with permission either given by the issuer or by the user