### PR TITLE
added multi-auth updates to lib api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenscript/token-negotiator",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenscript/token-negotiator",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@onflow/fcl": "^1.3.2",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -37,7 +37,6 @@ import { getFungibleTokenBalances, getFungibleTokensMeta } from '../utils/token/
 import { URLNS } from '../core/messaging'
 import { DecodedToken, TokenType } from '../outlet/ticketStorage'
 import { ProofResult } from '../outlet/auth-handler'
-import { sha256 } from 'ethers/lib/utils'
 
 if (typeof window !== 'undefined') window.tn = { VERSION }
 

--- a/src/outlet/__tests__/outlet.spec.ts
+++ b/src/outlet/__tests__/outlet.spec.ts
@@ -85,49 +85,50 @@ const EAS_TICKET_SCHEMA = {
 	],
 }
 
-async function createTestMagicLink(ticketType, ticketId, ticketClass) {
-	let ticketInUrl, secret
+// Commented for now to enable the build. Uncomment when needed.
+// async function createTestMagicLink(ticketType, ticketId, ticketClass) {
+// 	let ticketInUrl, secret
 
-	const email = 'test@test.com'
-	const issuerPrivKey =
-		'MIICSwIBADCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBBIIBVTCCAVECAQEEIM/T+SzcXcdtcNIqo6ck0nJTYzKL5ywYBFNSpI7R8AuBoIHjMIHgAgEBMCwGByqGSM49AQECIQD////////////////////////////////////+///8LzBEBCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncmo8RlXaT7/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu3OavSKA7v9JejNA2QUECAQGhRANCAARjMR62qoIK9pHk17MyHHIU42Ix+Vl6Q2gTmIF72vNpinBpyoBkTkV0pnI1jdrLlAjJC0I91DZWQhVhddMCK65c'
+// 	const email = 'test@test.com'
+// 	const issuerPrivKey =
+// 		'MIICSwIBADCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBBIIBVTCCAVECAQEEIM/T+SzcXcdtcNIqo6ck0nJTYzKL5ywYBFNSpI7R8AuBoIHjMIHgAgEBMCwGByqGSM49AQECIQD////////////////////////////////////+///8LzBEBCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncmo8RlXaT7/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu3OavSKA7v9JejNA2QUECAQGhRANCAARjMR62qoIK9pHk17MyHHIU42Ix+Vl6Q2gTmIF72vNpinBpyoBkTkV0pnI1jdrLlAjJC0I91DZWQhVhddMCK65c'
 
-	if (ticketType === 'eas') {
-		const provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC)
-		const wallet = new ethers.Wallet(KeyPair.privateFromPEM(issuerPrivKey).getPrivateAsHexString(), provider)
+// 	if (ticketType === 'eas') {
+// 		const provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC)
+// 		const wallet = new ethers.Wallet(KeyPair.privateFromPEM(issuerPrivKey).getPrivateAsHexString(), provider)
 
-		const attestationManager = new EasTicketAttestation(EAS_TICKET_SCHEMA, {
-			EASconfig: EAS_CONFIG,
-			signer: wallet,
-		})
+// 		const attestationManager = new EasTicketAttestation(EAS_TICKET_SCHEMA, {
+// 			EASconfig: EAS_CONFIG,
+// 			signer: wallet,
+// 		})
 
-		await attestationManager.createEasAttestation({
-			devconId: '6',
-			ticketIdString: ticketId,
-			ticketClass: ticketClass,
-			commitment: email,
-		})
+// 		await attestationManager.createEasAttestation({
+// 			devconId: '6',
+// 			ticketIdString: ticketId,
+// 			ticketClass: ticketClass,
+// 			commitment: email,
+// 		})
 
-		ticketInUrl = base64toBase64Url(attestationManager.getEncoded())
-		secret = attestationManager.getEasJson().secret
-	} else {
-		secret = BigInt(45845870684)
+// 		ticketInUrl = base64toBase64Url(attestationManager.getEncoded())
+// 		secret = attestationManager.getEasJson().secret
+// 	} else {
+// 		secret = BigInt(45845870684)
 
-		let ticket = Ticket.createWithMail(email, '6', ticketId, ticketClass, { '6': KeyPair.privateFromPEM(issuerPrivKey) }, secret)
+// 		let ticket = Ticket.createWithMail(email, '6', ticketId, ticketClass, { '6': KeyPair.privateFromPEM(issuerPrivKey) }, secret)
 
-		if (!ticket.checkValidity()) {
-			throw new Error('Ticket validity check failed')
-		}
+// 		if (!ticket.checkValidity()) {
+// 			throw new Error('Ticket validity check failed')
+// 		}
 
-		if (!ticket.verify()) {
-			throw new Error('Ticket verify failed')
-		}
+// 		if (!ticket.verify()) {
+// 			throw new Error('Ticket verify failed')
+// 		}
 
-		ticketInUrl = hexStringToBase64Url(ticket.getDerEncoding())
-	}
+// 		ticketInUrl = hexStringToBase64Url(ticket.getDerEncoding())
+// 	}
 
-	return new URLSearchParams(new URL(`http://127.0.0.1?type=${ticketType}&ticket=${ticketInUrl}&secret=${secret}&mail=${email}`).search)
-}
+// 	return new URLSearchParams(new URL(`http://127.0.0.1?type=${ticketType}&ticket=${ticketInUrl}&secret=${secret}&mail=${email}`).search)
+// }
 
 describe('Test TicketStorage', () => {
 	// @ts-ignore

--- a/src/outlet/ticketStorage.ts
+++ b/src/outlet/ticketStorage.ts
@@ -190,8 +190,7 @@ export class TicketStorage {
 
 			await this.easManager.validateEasAttestation()
 
-			// TODO: Implementation in progress towards EAS authentication.
-			// return this.easManager.getSignerKeyPair()
+			return this.easManager.getSignerKeyPair()
 		} else {
 			const ticket = Ticket.fromBase64(token, this.signingKeys)
 

--- a/src/outlet/whitelist.ts
+++ b/src/outlet/whitelist.ts
@@ -27,17 +27,16 @@ export class Whitelist {
 	}
 
 	private loadStaticWhitelist() {
+		if (!this.config.issuers) return
 		for (const { collectionID, whitelist } of this.config.issuers) {
 			if (whitelist)
 				for (let origin of whitelist) {
 					try {
 						origin = new URL(origin).origin
-
 						if (!this.staticWhitelist[origin]) {
 							this.staticWhitelist[origin] = [collectionID]
 							continue
 						}
-
 						this.staticWhitelist[origin].push(collectionID)
 					} catch (e) {
 						logger(2, 'Failed to validate whitelist origin: ' + e.message)


### PR DESCRIPTION
Adjusted the authenticate library method to support old single attestations and new multi.

authenticate is now a co-ordination method - 

is single token - it will return from authenticateToken()
is multi token - it will return many from athenticateMutilple() which uses, authenticateToken() per token