### PR TITLE
Switch default UN creation api to common-api

### DIFF
--- a/src/client/auth/signedUNChallenge.ts
+++ b/src/client/auth/signedUNChallenge.ts
@@ -6,7 +6,6 @@ import { logger } from '../../utils'
 
 export class SignedUNChallenge extends AbstractAuthentication implements AuthenticationMethodUN {
 	TYPE = 'signedUN'
-	private static DEFAULT_ENDPOINT = 'https://attestation-verify.tokenscript.org/un'
 
 	async getTokenProof(request: AuthenticateInterface): Promise<any> {
 		let web3WalletProvider = await this.client.getWalletProvider()
@@ -45,9 +44,7 @@ export class SignedUNChallenge extends AbstractAuthentication implements Authent
 				},
 			}
 
-			let endpoint = request.options?.unEndPoint ?? SignedUNChallenge.DEFAULT_ENDPOINT
-
-			const challenge = await UN.getNewUN(endpoint)
+			const challenge = await UN.getNewUN(request.options?.unEndPoint)
 			challenge.address = address
 			let signature
 

--- a/src/client/auth/util/UN.ts
+++ b/src/client/auth/util/UN.ts
@@ -15,9 +15,25 @@ export interface UNInterface {
 }
 
 export class UN {
+	private static DEFAULT_ENDPOINT = 'https://api.smarttokenlabs.com/un'
+	private static COMMON_API_KEY =
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoidG9rZW4tbmVnb3RpYXRvciIsImlhdCI6MTY4OTc1NzQ4Nn0.ELE1OVvVFY1yrWlbnxtQur6dgeVxmKlPb9LZ_8cMOs8'
+
 	public static async getNewUN(endPoint: string): Promise<UNInterface> {
 		try {
-			const response = await fetch(endPoint)
+			let response
+			if (endPoint) {
+				response = await fetch(endPoint)
+			} else {
+				response = await fetch(this.DEFAULT_ENDPOINT, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-stl-key': this.COMMON_API_KEY,
+					},
+					body: JSON.stringify({ targetDomain: window.location.origin }),
+				})
+			}
 
 			return await response.json()
 		} catch (e: any) {


### PR DESCRIPTION
As part of the `common-api` work, we migrated the UN creation API from `winding-tree`, and we made a change regarding the HTTP method from Get to Post, it's mainly because this endpoint is more like creating a new UN than reading an existing UN, but open to discuss.

__Note:__ We were planning to terminate the winding-tree backend later when this migration is released, especially considering the UN endpoint is only internally used by us, but please feel free to raise your concern if there is other unexpected impact (as the previous TN package will still have the default UN endpoint pointing to winding tree), cheers cc @foxgem