### PR TITLE
remove the requirement to send issuer id via authenticate method

### DIFF
--- a/src/client/__tests__/client.spec.ts
+++ b/src/client/__tests__/client.spec.ts
@@ -377,31 +377,15 @@ describe('client spec', () => {
 	})
 
 	test('tokenNegotiatorClient method authenticate', async () => {
-		const issuer = {
-			collectionID: 'devcon',
-			onChain: false,
-			title: 'Devcon',
-			image: 'https://raw.githubusercontent.com/TokenScript/token-negotiator/main/mock-images/devcon.svg',
-			tokenOrigin: 'http://localhost:3002/',
-			attestationOrigin: 'https://attestation.id/',
-			unEndPoint: 'https://crypto-verify.herokuapp.com/use-devcon-ticket',
-			base64senderPublicKeys: {
-				'6': 'MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBA0IABGMxHraqggr2keTXszIcchTjYjH5WXpDaBOYgXva82mKcGnKgGRORXSmcjWN2suUCMkLQj3UNlZCFWF10wIrrlw=',
-			},
-			base64attestorPubKey:
-				'MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////////////////////////////////////v///C8wRAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHBEEEeb5mfvncu6xVoGKVzocLBwKb/NstzijZWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuAIhAP////////////////////66rtzmr0igO7/SXozQNkFBAgEBA0IABL+y43T1OJFScEep69/yTqpqnV/jzONz9Sp4TEHyAJ7IPN9+GHweCX1hT4OFxt152sBN3jJc1s0Ymzd8pNGZNoQ=',
-		}
 		const tokenNegotiatorClient = getOffChainConfigClient()
-		tokenNegotiatorClient.getTokenStore().setTokens('devcon', [{ devcon: { a: 'true' } }])
-
+		tokenNegotiatorClient.getTokenStore().setTokens('devcon', [{ devcon: { a: 'true', collectionId: 'devcon' } }])
 		const authRequest = {
-			issuer: issuer,
-			unsignedToken: { devcon: { a: 'true' } },
+			unsignedToken: { a: 'true', collectionId: 'devcon' },
 		}
 		try {
 			await tokenNegotiatorClient.authenticate(authRequest)
 		} catch (err) {
-			expect(err).toEqual(new Error('Provided issuer was not found.'))
+			expect(err).toEqual(new Error('MetaMask is not available. Please check the extension is supported and active.'))
 		}
 	})
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -319,7 +319,6 @@ export class Client {
 			const { Web3WalletProvider } = await import('./../wallet/Web3WalletProvider')
 			this.web3WalletProvider = new Web3WalletProvider(this, this.config.walletOptions, this.config.safeConnectOptions)
 		}
-
 		return this.web3WalletProvider
 	}
 
@@ -785,9 +784,10 @@ export class Client {
 
 	async prepareToAuthenticateToken(authRequest: AuthenticateInterface) {
 		await this.checkUserAgentSupport('authentication')
-		const { issuer, unsignedToken, tokenId } = authRequest
-		requiredParams(issuer && (unsignedToken || tokenId), 'Issuer and unsigned token required.')
-		const config = this.tokenStore.getCurrentIssuers()[issuer]
+		const { unsignedToken, tokenId } = authRequest
+		if (!authRequest.issuer) authRequest.issuer = unsignedToken?.collectionId
+		requiredParams(authRequest.issuer && (unsignedToken || tokenId), 'Issuer and unsigned token required.')
+		const config = this.tokenStore.getCurrentIssuers()[authRequest.issuer]
 		if (!config) errorHandler('Provided issuer was not found.', 'error', null, null, true, true)
 		return authRequest
 	}
@@ -900,7 +900,8 @@ export class Client {
 	async authenticateToken(authRequest: AuthenticateInterface) {
 		await this.checkUserAgentSupport('authentication')
 
-		const { issuer, unsignedToken } = authRequest
+		const { unsignedToken } = authRequest
+		const issuer = unsignedToken.collectionId
 
 		requiredParams(issuer && unsignedToken, 'Issuer and unsigned token required.')
 


### PR DESCRIPTION
Adjusted the logic to utilise the attestations collection id. Removed the need for the end developer to send this separately to the unsigned token.

The code changes have been made and smoke tested across the examples for single and multi. 

