### PR TITLE
Feat: rpc and revoke check options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@onflow/fcl": "^1.3.2",
         "@onflow/types": "^1.0.5",
         "@peculiar/asn1-schema": "^2.2.0",
-        "@tokenscript/attestation": "0.5.1",
+        "@tokenscript/attestation": "0.6.0-rc.1",
         "@toruslabs/torus-embed": "^2.2.5",
         "@walletconnect/types": "^2.1.5",
         "@walletconnect/universal-provider": "^2.4.5",
@@ -4703,9 +4703,9 @@
       }
     },
     "node_modules/@tokenscript/attestation": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.5.1.tgz",
-      "integrity": "sha512-kJM6zrkVP/r/5dv0vRcLH5ScvKfgqmYFfn5w7Rnsu27dNqzvCC3vbW8vBUMsn3+ySwXNzlVgw4IxdsmvpLUqsQ==",
+      "version": "0.6.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.6.0-rc.1.tgz",
+      "integrity": "sha512-lIDfyPcDNyxcbqMBdgI/EGSo/MoHBjgLxLq+Ke8+m5B9bwLeoY1mDF0PqLGiAddX3tJGlTW4hY3tjNTyK93ugw==",
       "hasInstallScript": true,
       "dependencies": {
         "@ethereum-attestation-service/eas-sdk": "^0.28.3",
@@ -23297,9 +23297,9 @@
       }
     },
     "@tokenscript/attestation": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.5.1.tgz",
-      "integrity": "sha512-kJM6zrkVP/r/5dv0vRcLH5ScvKfgqmYFfn5w7Rnsu27dNqzvCC3vbW8vBUMsn3+ySwXNzlVgw4IxdsmvpLUqsQ==",
+      "version": "0.6.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@tokenscript/attestation/-/attestation-0.6.0-rc.1.tgz",
+      "integrity": "sha512-lIDfyPcDNyxcbqMBdgI/EGSo/MoHBjgLxLq+Ke8+m5B9bwLeoY1mDF0PqLGiAddX3tJGlTW4hY3tjNTyK93ugw==",
       "requires": {
         "@ethereum-attestation-service/eas-sdk": "^0.28.3",
         "@peculiar/asn1-schema": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@onflow/fcl": "^1.3.2",
     "@onflow/types": "^1.0.5",
     "@peculiar/asn1-schema": "^2.2.0",
-    "@tokenscript/attestation": "0.5.1",
+    "@tokenscript/attestation": "0.6.0-rc.1",
     "@toruslabs/torus-embed": "^2.2.5",
     "@walletconnect/types": "^2.1.5",
     "@walletconnect/universal-provider": "^2.4.5",

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -55,7 +55,7 @@ export interface IssuerConfigInterface {
 export type Issuer = OffChainTokenConfig | SolanaIssuerConfig | OnChainTokenConfig | UltraIssuerConfig
 export type OnChainIssuer = SolanaIssuerConfig | OnChainTokenConfig | UltraIssuerConfig
 export interface NegotiationInterface {
-	type: string
+	type: 'active' | 'passive'
 	issuers?: Issuer[]
 	uiOptions?: UIOptionsInterface
 	autoLoadTokens?: number | boolean
@@ -64,6 +64,8 @@ export interface NegotiationInterface {
 	safeConnectOptions?: SafeConnectOptions
 	offChainRedirectMode?: 'always' | 'never'
 	tokenPersistenceTTL?: number
+	ethRpcMap?: EthRPCMap
+	skipEasRevokeCheck?: boolean
 	unSupportedUserAgent?: {
 		authentication?: {
 			config: BrowserDataInterface
@@ -79,10 +81,13 @@ export interface NegotiationInterface {
 	walletOptions?: WalletOptionsInterface
 }
 
+export interface EthRPCMap {
+	[chainId: number]: string
+}
+
 export interface WalletOptionsInterface {
 	walletConnectV2?: {
 		chains?: string[]
-		rpcMap: { [chainId: string]: string }
 	}
 }
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_RPC_MAP = {
+	1: 'https://ethereum.publicnode.com', // mainnet
+	5: 'https://eth-goerli.g.alchemy.com/v2/yVhq9zPJorAWsw-F87fEabSUl7cCU6z4', // Goerli
+	11155111: 'https://sepolia.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef', // Sepolia
+	137: 'https://polygon-rpc.com/', // Polygon
+	80001: 'https://polygon-mumbai.g.alchemy.com/v2/rVI6pOV4irVsrw20cJxc1fxK_1cSeiY0', // mumbai
+	56: 'https://bsc-dataseed.binance.org/', // BSC,
+	97: 'https://data-seed-prebsc-1-s1.binance.org:8545', // BSC testnet
+	43114: 'https://api.avax.network/ext/bc/C/rpc', // Avalanche
+	43113: 'https://api.avax-test.network/ext/bc/C/rpc', // Fuji testnet
+	250: 'https://rpc.fantom.network/', // Fantom,
+	25: 'https://evm-cronos.crypto.org', // Cronos,
+	338: 'https://evm-t3.cronos.org', // Cronos testnet
+	42161: 'https://arb1.arbitrum.io/rpc', // Arbitrum
+	421613: 'https://arb-goerli.g.alchemy.com/v2/nFrflomLgsQQL5NWjGileAVqIGGxZWce', // Arbitrum goerli,
+	10: 'https://mainnet.optimism.io', // Optimism
+}

--- a/src/core/eas.ts
+++ b/src/core/eas.ts
@@ -1,4 +1,0 @@
-export const EAS_RPC_CONFIG = {
-	1: 'https://eth-mainnet.g.alchemy.com/v2/2bJxn0VGXp9U5EOfA6CoMGU-rrd-BIIT',
-	11155111: 'https://rpc.sepolia.org/',
-}

--- a/src/outlet/getUseToken.ts
+++ b/src/outlet/getUseToken.ts
@@ -1,15 +1,17 @@
 import { DEFAULT_EAS_SCHEMA, StoredTicketRecord } from './ticketStorage'
 import { EasZkProof } from '@tokenscript/attestation/dist/eas/EasZkProof'
-import { EAS_RPC_CONFIG } from '../core/eas'
 import { Authenticator } from '@tokenscript/attestation'
 import { logger } from '../utils'
 import { OutletIssuerInterface, ProofResult } from './interfaces'
+import { DEFAULT_RPC_MAP } from '../core/constants'
+import { EthRPCMap } from '../client/interface'
 
 export const getUseToken = async (
 	issuerConfig: OutletIssuerInterface,
 	attestationBlob: string,
 	attestationSecret: string,
 	ticketRecord: StoredTicketRecord,
+	ethRpcMap?: EthRPCMap,
 ) => {
 	try {
 		if (!ticketRecord.secret) {
@@ -36,7 +38,7 @@ export const getUseToken = async (
 		if (ticketRecord.type === 'eas') {
 			const schema = issuerConfig.eas ? { fields: issuerConfig.eas.fields } : DEFAULT_EAS_SCHEMA
 
-			const easZkProof = new EasZkProof(schema, EAS_RPC_CONFIG)
+			const easZkProof = new EasZkProof(schema, { ...DEFAULT_RPC_MAP, ...ethRpcMap })
 			useToken = easZkProof.getUseTicket(
 				BigInt(ticketRecord.secret),
 				BigInt(attestationSecret),

--- a/src/outlet/index.ts
+++ b/src/outlet/index.ts
@@ -25,7 +25,7 @@ export class Outlet extends LocalOutlet {
 		private tokenConfig: OutletInterface,
 		urlParams: URLSearchParams = null,
 	) {
-		super(tokenConfig.issuers)
+		super(tokenConfig)
 
 		this.tokenConfig = Object.assign(defaultConfig, tokenConfig)
 

--- a/src/outlet/interfaces.ts
+++ b/src/outlet/interfaces.ts
@@ -1,8 +1,11 @@
 import { TokenType } from './ticketStorage'
 import { AbiFieldTypes } from '@tokenscript/attestation/dist/eas/EasTicketAttestation'
+import { EthRPCMap } from '../client/interface'
 
 export interface OutletInterface {
 	issuers: OutletIssuerInterface[]
+	ethRpcMap?: EthRPCMap
+	skipEasRevokeCheck?: boolean
 	whitelistDialogWidth?: string
 	whitelistDialogHeight?: string
 	whitelistDialogRenderer?: (permissionTxt: string, acceptBtn: string, denyBtn: string) => string

--- a/src/outlet/localOutlet.ts
+++ b/src/outlet/localOutlet.ts
@@ -2,14 +2,14 @@ import { DecodedToken, TicketStorage } from './ticketStorage'
 import { IssuerHashMap, logger } from '../utils'
 import { AttestationIdClient } from './attestationIdClient'
 import { getUseToken } from './getUseToken'
-import { MultiTokenAuthRequest, MultiTokenAuthResult, OutletIssuerInterface } from './interfaces'
+import { MultiTokenAuthRequest, MultiTokenAuthResult, OutletInterface, OutletIssuerInterface } from './interfaces'
 import { OutletAction } from '../client/messaging'
 
 export class LocalOutlet {
 	protected ticketStorage: TicketStorage
 
-	constructor(issuers: OutletIssuerInterface[]) {
-		this.ticketStorage = new TicketStorage(issuers)
+	constructor(config: OutletInterface) {
+		this.ticketStorage = new TicketStorage(config)
 	}
 
 	public async readMagicLink(urlParams: URLSearchParams) {

--- a/src/wallet/WalletConnectV2Provider.ts
+++ b/src/wallet/WalletConnectV2Provider.ts
@@ -1,23 +1,5 @@
 import UniversalProvider from '@walletconnect/universal-provider'
 
-export const WC_DEFAULT_RPC_MAP = {
-	1: 'https://ethereum.publicnode.com', // mainnet
-	5: 'https://eth-goerli.g.alchemy.com/v2/yVhq9zPJorAWsw-F87fEabSUl7cCU6z4', // Goerli
-	11155111: 'https://sepolia.infura.io/v3/9f79b2f9274344af90b8d4e244b580ef', // Sepolia
-	137: 'https://polygon-rpc.com/', // Polygon
-	80001: 'https://polygon-mumbai.g.alchemy.com/v2/rVI6pOV4irVsrw20cJxc1fxK_1cSeiY0', // mumbai
-	56: 'https://bsc-dataseed.binance.org/', // BSC,
-	97: 'https://data-seed-prebsc-1-s1.binance.org:8545', // BSC testnet
-	43114: 'https://api.avax.network/ext/bc/C/rpc', // Avalanche
-	43113: 'https://api.avax-test.network/ext/bc/C/rpc', // Fuji testnet
-	250: 'https://rpc.fantom.network/', // Fantom,
-	25: 'https://evm-cronos.crypto.org', // Cronos,
-	338: 'https://evm-t3.cronos.org', // Cronos testnet
-	42161: 'https://arb1.arbitrum.io/rpc', // Arbitrum
-	421613: 'https://arb-goerli.g.alchemy.com/v2/nFrflomLgsQQL5NWjGileAVqIGGxZWce', // Arbitrum goerli,
-	10: 'https://mainnet.optimism.io', // Optimism
-}
-
 export const WC_V2_DEFAULT_CHAINS = [
 	'eip155:1', // Mainnet
 	// 'eip155:5',

--- a/src/wallet/Web3WalletProvider.ts
+++ b/src/wallet/Web3WalletProvider.ts
@@ -3,6 +3,7 @@ import { logger, strToHexStr, strToUtfBytes } from '../utils'
 import { SafeConnectOptions } from './SafeConnectProvider'
 import { Client } from '../client'
 import { SupportedBlockchainsParam, WalletOptionsInterface, SignatureSupportedBlockchainsParamList } from '../client/interface'
+import { DEFAULT_RPC_MAP } from '../core/constants'
 
 interface WalletConnectionState {
 	[index: string]: WalletConnection
@@ -412,7 +413,7 @@ export class Web3WalletProvider {
 								methods: ['eth_sendTransaction', 'eth_signTransaction', 'eth_sign', 'personal_sign', 'eth_signTypedData'],
 								chains: preSavedWalletOptions?.walletConnectV2?.chains ?? walletConnectProvider.WC_V2_DEFAULT_CHAINS,
 								events: ['chainChanged', 'accountsChanged'],
-								rpcMap: preSavedWalletOptions?.walletConnectV2?.rpcMap ?? walletConnectProvider.WC_DEFAULT_RPC_MAP,
+								rpcMap: { ...DEFAULT_RPC_MAP, ...this.client.config.ethRpcMap },
 							},
 						},
 					})


### PR DESCRIPTION
- Add option to specify custom RPC map for use in EAS revocation checking & walletconnect connections.
  Each key (chain) in the config overrides the default inbuilt URLs.
- Add option to skip revocation check when importing the attestation into the outlet.